### PR TITLE
Update storage node metadata

### DIFF
--- a/packages/docker-dev-chain-init/index.js
+++ b/packages/docker-dev-chain-init/index.js
@@ -240,7 +240,7 @@ async function deployStreamRegistries() {
     initialNodes = []
     initialMetadata = []
     initialNodes.push('0xde1112f631486CfC759A50196853011528bC5FA0')
-    initialMetadata.push('{"http": "http://10.200.10.1:8891/api/v1"}')
+    initialMetadata.push('{"http": "http://10.200.10.1:8891"}')
     const strDeploy = await ethers.getContractFactory("NodeRegistry", sidechainWalletStreamReg)
     // const strDeploy = await ethers.getContractFactory('NodeRegistry')
     const strDeployTx = await upgrades.deployProxy(strDeploy, 
@@ -442,7 +442,7 @@ async function smartContractInitialization() {
     initialNodes = []
     initialMetadata = []
     initialNodes.push('0xde1112f631486CfC759A50196853011528bC5FA0')
-    initialMetadata.push('{"http": "http://10.200.10.1:8891/api/v1"}')
+    initialMetadata.push('{"http": "http://10.200.10.1:8891"}')
     await deployNodeRegistry(sidechainWallet, initialNodes, initialMetadata)
 
     log(`deploy Uniswap2 mainnet`)


### PR DESCRIPTION
The storage node endpoints don't have `/api/v1` prefix after this PR: https://github.com/streamr-dev/network-monorepo/pull/408