### PR TITLE
[ETH-389] Add method to request access to tokenGated streams without a delegated wallet

### DIFF
--- a/packages/smartcontracts/contracts/GatedChatRooms/ERC1155JoinPolicy.sol
+++ b/packages/smartcontracts/contracts/GatedChatRooms/ERC1155JoinPolicy.sol
@@ -50,4 +50,11 @@ contract ERC1155JoinPolicy is GatedJoinPolicy {
     {
         accept(msg.sender, delegatedWallet);
     }
+
+    function requestJoin(uint256 tokenId_)
+        public
+        canJoin(tokenId_)
+    {
+        accept(msg.sender);
+    }
 }

--- a/packages/smartcontracts/contracts/GatedChatRooms/ERC20JoinPolicy.sol
+++ b/packages/smartcontracts/contracts/GatedChatRooms/ERC20JoinPolicy.sol
@@ -45,6 +45,13 @@ contract ERC20JoinPolicy is GatedJoinPolicy{
         accept(msg.sender, delegatedWallet);
     }
 
+    function requestJoin()
+        public
+        canJoin()
+    {
+        accept(msg.sender);
+    }
+
 
 
 }

--- a/packages/smartcontracts/contracts/GatedChatRooms/ERC721JoinPolicy.sol
+++ b/packages/smartcontracts/contracts/GatedChatRooms/ERC721JoinPolicy.sol
@@ -41,5 +41,12 @@ contract ERC721JoinPolicy is GatedJoinPolicy{
         accept(msg.sender, delegatedWallet);
     }
 
+    function requestJoin(uint256 tokenId_)
+        public
+        canJoin(tokenId_)
+    {
+        accept(msg.sender);
+    }
+
     
 }

--- a/packages/smartcontracts/contracts/GatedChatRooms/GatedJoinPolicy.sol
+++ b/packages/smartcontracts/contracts/GatedChatRooms/GatedJoinPolicy.sol
@@ -31,6 +31,12 @@ contract GatedJoinPolicy{
         _;
     }
 
+    function accept(address mainWallet) internal {
+        for (uint256 i = 0; i < permissions.length; i++) {
+            streamRegistry.grantPermission(streamId, mainWallet, permissions[i]);
+        }
+        emit Accepted(mainWallet, address(0x0));
+    }
 
     function accept(address mainWallet, address delegatedWallet) internal {
         for (uint256 i = 0; i < permissions.length; i++) {

--- a/packages/smartcontracts/test/GatedChatRooms/ERC1155JoinPolicy.test.ts
+++ b/packages/smartcontracts/test/GatedChatRooms/ERC1155JoinPolicy.test.ts
@@ -208,4 +208,20 @@ describe('ERC1155JoinPolicy', (): void => {
             PermissionType.Grant
         )).to.equal(false)
     })
+
+    it ('should grant requestJoin to a user with enough balance', async () => {
+        await contract.connect(wallets[0]).requestJoin(TokenIds.A)
+
+        const events = await contract.queryFilter(
+            contract.filters.Accepted()
+        )
+        expect(events.length).to.equal(2)
+        expect(events[1].args).to.not.be.undefined
+        expect(events[1].args!.mainWallet).to.equal(
+            wallets[0].address
+        )
+        expect(events[1].args!.delegatedWallet).to.equal(
+            '0x0000000000000000000000000000000000000000'
+        )
+    })
 })

--- a/packages/smartcontracts/test/GatedChatRooms/ERC20JoinPolicy.test.ts
+++ b/packages/smartcontracts/test/GatedChatRooms/ERC20JoinPolicy.test.ts
@@ -201,4 +201,20 @@ describe('ERC20JoinPolicy', (): void => {
         )).to.equal(false)
     })
 
+    it ('should grant requestJoin to a user with enough balance', async () => {
+        await contract.connect(wallets[1]).requestJoin()
+
+        const events = await contract.queryFilter(
+            contract.filters.Accepted()
+        )
+        expect(events.length).to.equal(2)
+        expect(events[1].args).to.not.be.undefined
+        expect(events[1].args!.mainWallet).to.equal(
+            wallets[1].address
+        )
+        expect(events[1].args!.delegatedWallet).to.equal(
+            '0x0000000000000000000000000000000000000000'
+        )
+    })
+
 })

--- a/packages/smartcontracts/test/GatedChatRooms/ERC721JoinPolicy.test.ts
+++ b/packages/smartcontracts/test/GatedChatRooms/ERC721JoinPolicy.test.ts
@@ -210,4 +210,20 @@ describe('ERC721JoinPolicy', (): void => {
         )).to.equal(false)
     })
 
+    it ('should grant requestJoin to a user with enough balance', async () => {
+        await contract.connect(wallets[1]).requestJoin(TokenId)
+
+        const events = await contract.queryFilter(
+            contract.filters.Accepted()
+        )
+        expect(events.length).to.equal(2)
+        expect(events[1].args).to.not.be.undefined
+        expect(events[1].args!.mainWallet).to.equal(
+            wallets[1].address
+        )
+        expect(events[1].args!.delegatedWallet).to.equal(
+            '0x0000000000000000000000000000000000000000'
+        )
+    })
+
 })


### PR DESCRIPTION
- added requestJoin() method on ERC20JoinPolicy
- add requestJoin(tokenId) method on NFT join policies (ERC721JoinPolicy, ERC1155JoinPolicy)
- add method accept(mainWallet) to parent contract GatedJoinPolicy to properly assign permissions to calls without a delegated wallets
- recycle the Accepted event, having its first parameter be the caller wallet and the second, the 0x0 address