### PR TITLE
feat: add isDataUnion flag to Project entity

### DIFF
--- a/packages/hub-subgraph/schema.graphql
+++ b/packages/hub-subgraph/schema.graphql
@@ -15,13 +15,13 @@ type Permission @entity {
   userAddress: Bytes!
   "Target project this permission applies to"
   project: Project!
-  "Buy permission enables a user to buy the project"
+  "canBuy permission enables a user to buy the project"
   canBuy: Boolean
   "canDelete permission allows deleting the project from the ProjectRegistry"
   canDelete: Boolean
-  "Edit permission enables changing the project's fields"
+  "canEdit permission enables changing the project's fields"
   canEdit: Boolean
-  "Grant permission allows granting and revoking permissions to this project"
+  "canGrant permission allows granting and revoking permissions to this project"
   canGrant: Boolean
 }
 
@@ -32,11 +32,11 @@ type PaymentDetailsByChain @entity {
   project: Project!
   "The domainId of the chain where the project can be purchased. It's a unique id assigned by hyperlane to each chain"
   domainId: BigInt
-  "Ethereum address, account where revenue is directed to for project purchases"
+  "Ethereum address, account where the payment is directed to for project purchases"
   beneficiary: Bytes!
-  "Ethereum address, the token in which the project is paid to project beneficiary"
+  "Ethereum address, the token in which the payment goes to project beneficiary"
   pricingTokenAddress: Bytes!
-  "Project price per second. This is a wei denominated amount"
+  "Project price per second. This is a DATA-wei denominated amount (10^18th of DATA token)."
   pricePerSecond: BigInt
 }
 
@@ -64,7 +64,7 @@ type Project @entity {
   subscriptions: [TimeBasedSubscription!]! @derivedFrom(field: "project")
   "Project metadata JSON"
   metadata: String!
-  "Flaggs a project as being a data union if 'isDataUnion' field is set to 'true' in the metadata"
+  "Flags a project as being a data union, true iff 'isDataUnion' field is set to 'true' in the metadata JSON"
   isDataUnion: Boolean
   "Project version. This is a normal int value (not wei)"
   version: BigInt

--- a/packages/hub-subgraph/schema.graphql
+++ b/packages/hub-subgraph/schema.graphql
@@ -64,6 +64,8 @@ type Project @entity {
   subscriptions: [TimeBasedSubscription!]! @derivedFrom(field: "project")
   "Project metadata JSON"
   metadata: String!
+  "Flaggs a project as being a data union if 'isDataUnion' field is set to 'true' in the metadata"
+  isDataUnion: Boolean
   "Project version. This is a normal int value (not wei)"
   version: BigInt
   "Streams added to the project"

--- a/packages/hub-subgraph/src/helpers.ts
+++ b/packages/hub-subgraph/src/helpers.ts
@@ -1,4 +1,4 @@
-import { BigInt, Bytes } from "@graphprotocol/graph-ts"
+import { BigInt, Bytes, json, JSONValue, JSONValueKind, Result } from "@graphprotocol/graph-ts"
 import { Project } from '../generated/schema'
 
 /**
@@ -16,6 +16,23 @@ export function loadOrCreateProject(projectId: Bytes): Project {
         project.createdAt = BigInt.fromI32(0)
         project.counter = 0
         project.score = BigInt.fromI32(0)
+        project.isDataUnion = false
     }
     return project
+}
+
+/**
+ * Parse string to JSON and return the value of the "isDataUnion" key.
+ * @dev https://thegraph.com/docs/en/developing/assemblyscript-api/#json-api
+ */
+export function getIsDataUnionValue(jsonString: string): boolean {
+    let result: Result<JSONValue, boolean> = json.try_fromString(jsonString)
+    if (result.isOk && result.value.kind == JSONValueKind.OBJECT) {
+        let resultObj = result.value.toObject()
+        let isDataUnionOrNull: JSONValue | null = resultObj.get("isDataUnion")
+        return isDataUnionOrNull == null
+            ? false
+            : isDataUnionOrNull.toBool()
+    }
+    return false
 }

--- a/packages/hub-subgraph/src/projectRegistry.ts
+++ b/packages/hub-subgraph/src/projectRegistry.ts
@@ -10,7 +10,7 @@ import {
     StreamRemoved,
     PaymentDetailsByChainUpdated,
 } from '../generated/ProjectRegistry/ProjectRegistry'
-import { loadOrCreateProject } from './helpers'
+import { getIsDataUnionValue, loadOrCreateProject } from './helpers'
 
 export function handleProjectCreation(event: ProjectCreated): void {
     const id = event.params.id.toHexString()
@@ -23,6 +23,7 @@ export function handleProjectCreation(event: ProjectCreated): void {
     project.domainIds = event.params.domainIds
     project.minimumSubscriptionSeconds = event.params.minimumSubscriptionSeconds
     project.metadata = metadata
+    project.isDataUnion = getIsDataUnionValue(metadata)
     project.streams = event.params.streams
     project.createdAt = event.block.timestamp
     project.counter = 0
@@ -48,6 +49,7 @@ export function handleProjectUpdate(event: ProjectUpdated): void {
     project.streams = event.params.streams
     project.minimumSubscriptionSeconds = event.params.minimumSubscriptionSeconds
     project.metadata = event.params.metadata
+    project.isDataUnion = getIsDataUnionValue(event.params.metadata)
     project.updatedAt = event.block.timestamp
     project.save()
 }

--- a/packages/hub-subgraph/tests/helpers/mocked-entity.ts
+++ b/packages/hub-subgraph/tests/helpers/mocked-entity.ts
@@ -8,6 +8,7 @@ export function createProjectEntity(projectId: string): Project {
     project.paymentDetails = []
     project.minimumSubscriptionSeconds = BigInt.fromI32(1)
     project.metadata = "metadata-" + projectId
+    project.isDataUnion = false
     project.version = BigInt.fromI32(1)
     project.subscriptions = []
     project.streams = []

--- a/packages/hub-subgraph/tests/helpers/mocked-event.ts
+++ b/packages/hub-subgraph/tests/helpers/mocked-event.ts
@@ -16,6 +16,7 @@ import {
     Stake,
     Unstake,
  } from "../../generated/ProjectStakingV1/ProjectStakingV1"
+import { getIsDataUnionValue } from "../../src/helpers"
 
 //////////////////////// ProjectRegistry ////////////////////////
 
@@ -47,6 +48,8 @@ export function createProjectCreatedEvent(
     projectCreatedEvent.parameters.push(minSubSecondsParam)
     const metadataParam = new ethereum.EventParam("metadata", ethereum.Value.fromString(metadata))
     projectCreatedEvent.parameters.push(metadataParam)
+    const isDataUnionParam = new ethereum.EventParam("isDataUnion", ethereum.Value.fromBoolean(getIsDataUnionValue(metadata)))
+    projectCreatedEvent.parameters.push(isDataUnionParam)
     
     return projectCreatedEvent
 }
@@ -81,6 +84,8 @@ export function createProjectUpdatedEvent(
     projectUpdatedEvent.parameters.push(minSubSecondsParam)
     const metadataParam = new ethereum.EventParam("metadata", ethereum.Value.fromString(metadata))
     projectUpdatedEvent.parameters.push(metadataParam)
+    const isDataUnionParam = new ethereum.EventParam("isDataUnion", ethereum.Value.fromBoolean(getIsDataUnionValue(metadata)))
+    projectUpdatedEvent.parameters.push(isDataUnionParam)
     
     return projectUpdatedEvent
 }

--- a/packages/hub-subgraph/tests/projectRegistry.test.ts
+++ b/packages/hub-subgraph/tests/projectRegistry.test.ts
@@ -91,7 +91,7 @@ describe("Mocked Project Events: create/update/delete", () => {
     const streamId1 = "0x12345/streams/1"
     const streamId2 = "0x12345/streams/2"
     const minimumSubscriptionSeconds = 1
-    const metadata = "metadata-0x1234"
+    const metadata = '{"description": "metadata-0x1234", "isDataUnion": false}'
     
     test("handleProjectCreation", () => {
         const projectCreatedEvent = createProjectCreatedEvent(
@@ -111,12 +111,53 @@ describe("Mocked Project Events: create/update/delete", () => {
         assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId, "streams", `[${streamId1}]`)
         assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId, "minimumSubscriptionSeconds", `${minimumSubscriptionSeconds}`)
         assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId, "metadata", metadata)
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId, "isDataUnion", "false")
+    })
+
+    test("handleProjectCreation - isDataUnion edge cases", () => {
+        let projectId0 = "0x1000"
+        let projectId1 = "0x1001"
+        let projectId2 = "0x1002"
+        let projectId3 = "0x1003"
+        let projectId4 = "0x1004"
+        let projectId5 = "0x1005"
+        let projectId6 = "0x1006"
+        let metadata0 = ''                                                                      // false
+        let metadata1 = 'string, not json'                                                      // false
+        let metadata2 = '{}'                                                                    // false
+        let metadata3 = '{"isDataUnion": true, otherField: "invalid json, missing key quotes"}' // false
+        let metadata4 = '{"isDataUnion": false}'                                                // false
+        let metadata5 = '{"isDataUnion": true}'                                                 // true
+        let metadata6 = '{"isDataUnion": true, "description": "metadata-0x1006"}'               // true
+        let event0 = createProjectCreatedEvent(Bytes.fromHexString(projectId0), [], [], [], 0, metadata0)
+        let event1 = createProjectCreatedEvent(Bytes.fromHexString(projectId1), [], [], [], 0, metadata1)
+        let event2 = createProjectCreatedEvent(Bytes.fromHexString(projectId2), [], [], [], 0, metadata2)
+        let event3 = createProjectCreatedEvent(Bytes.fromHexString(projectId3), [], [], [], 0, metadata3)
+        let event4 = createProjectCreatedEvent(Bytes.fromHexString(projectId4), [], [], [], 0, metadata4)
+        let event5 = createProjectCreatedEvent(Bytes.fromHexString(projectId5), [], [], [], 0, metadata5)
+        let event6 = createProjectCreatedEvent(Bytes.fromHexString(projectId6), [], [], [], 0, metadata6)
+
+        handleProjectCreation(event0)
+        handleProjectCreation(event1)
+        handleProjectCreation(event2)
+        handleProjectCreation(event3)
+        handleProjectCreation(event4)
+        handleProjectCreation(event5)
+        handleProjectCreation(event6)
+
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId0, "isDataUnion", "false")
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId1, "isDataUnion", "false")
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId2, "isDataUnion", "false")
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId3, "isDataUnion", "false")
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId4, "isDataUnion", "false")
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId5, "isDataUnion", "true")
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId6, "isDataUnion", "true")
     })
 
     test("handleProjectUpdate", () => {
         const domainIdUpdated = 2222
         const minimumSubscriptionSecondsNew = 5
-        const metadataNew = "metadata-0x1234-updated"
+        const metadataNew = '{"description": "metadata-0x1234-updated", "isDataUnion": true}'
         const projectUpdatedEvent = createProjectUpdatedEvent(
             Bytes.fromHexString(projectId),
             [domainIdUpdated],
@@ -132,6 +173,47 @@ describe("Mocked Project Events: create/update/delete", () => {
         assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId, "streams", `[${streamId2}]`)
         assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId, "minimumSubscriptionSeconds", `${minimumSubscriptionSecondsNew}`)
         assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId, "metadata", metadataNew)
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId, "isDataUnion", "true")
+    })
+
+    test("handleProjectUpdate - isDataUnion edge cases", () => {
+        let projectId0 = "0x2000"
+        let metadata0 = ''                                                                      // false
+        let metadata1 = 'string, not json'                                                      // false
+        let metadata2 = '{}'                                                                    // false
+        let metadata3 = '{"isDataUnion": true, otherField: "invalid json, missing key quotes"}' // false
+        let metadata4 = '{"isDataUnion": false}'                                                // false
+        let metadata5 = '{"isDataUnion": true}'                                                 // true
+        let metadata6 = '{"isDataUnion": true, "description": "metadata-0x1006"}'               // true
+        let event0 = createProjectCreatedEvent(Bytes.fromHexString(projectId0), [], [], [], 0, metadata0)
+        let event1 = createProjectUpdatedEvent(Bytes.fromHexString(projectId0), [], [], [], 0, metadata1)
+        let event2 = createProjectUpdatedEvent(Bytes.fromHexString(projectId0), [], [], [], 0, metadata2)
+        let event3 = createProjectUpdatedEvent(Bytes.fromHexString(projectId0), [], [], [], 0, metadata3)
+        let event4 = createProjectUpdatedEvent(Bytes.fromHexString(projectId0), [], [], [], 0, metadata4)
+        let event5 = createProjectUpdatedEvent(Bytes.fromHexString(projectId0), [], [], [], 0, metadata5)
+        let event6 = createProjectUpdatedEvent(Bytes.fromHexString(projectId0), [], [], [], 0, metadata6)
+
+        
+        handleProjectCreation(event0)
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId0, "isDataUnion", "false")
+
+        handleProjectUpdate(event1)
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId0, "isDataUnion", "false")
+
+        handleProjectUpdate(event2)
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId0, "isDataUnion", "false")
+
+        handleProjectUpdate(event3)
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId0, "isDataUnion", "false")
+
+        handleProjectUpdate(event4)
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId0, "isDataUnion", "false")
+
+        handleProjectUpdate(event5)
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId0, "isDataUnion", "true")
+
+        handleProjectUpdate(event6)
+        assert.fieldEquals(PROJECT_ENTITY_TYPE, projectId0, "isDataUnion", "true")
     })
 
     test("handleProjectDeletion - positivetest", () => {


### PR DESCRIPTION
Parse the project metadata and if "isDataUnion" field is found, set it's value in the subgraph entity. 
If it's not found, or the metadata is not a valid json, mark the project as non du.