### PR TITLE
VoteKickPolicy timeline: first review period, then voting period

### DIFF
--- a/packages/network-contracts/contracts/BrokerEconomics/Bounty.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/Bounty.sol
@@ -185,9 +185,12 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
         address broker = _msgSender();
         require(globalData().committedStakeWei[broker] == 0, "error_activeFlag");
         uint penaltyWei = getLeavePenalty(broker);
-        _slash(broker, penaltyWei, false);
+        // console.log("Leave penalty", penaltyWei);
+        if (penaltyWei > 0) {
+            _slash(broker, penaltyWei, false);
+            _addSponsorship(address(this), penaltyWei);
+        }
         _removeBroker(broker);
-        _addSponsorship(address(this), penaltyWei);
     }
 
     /**
@@ -215,15 +218,36 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
         //   in order to pay for all the flags AND still afford to get slashed 10%
         require(cashoutWei <= maxStakeReduction(broker), "error_cannotReduceStake");
 
-        globalData().stakedWei[broker] -= cashoutWei;
-        globalData().totalStakedWei -= cashoutWei;
-        moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onStakeDecrease.selector, broker, cashoutWei), "error_stakeDecreaseFailed");
-        uint penaltyWei = getLeavePenalty(broker);
-        require(cashoutWei > penaltyWei, "error_stakeWouldBeLostToPenalty");
-        token.transfer(broker, cashoutWei - penaltyWei);
-        if (penaltyWei > 0) {
-            _addSponsorship(address(this), penaltyWei);
+        _reduceStakeBy(broker, cashoutWei);
+        // console.log("reduceStake ->", broker, cashoutWei);
+        require(token.transferAndCall(broker, cashoutWei, "reduceStake"), "error_transfer");
+    }
+
+    /**
+     * Slashing moves tokens from a broker's stake to "free funds" (that are not in unallocatedFunds!)
+     * @dev The caller MUST ensure those tokens are added to some other account, e.g. unallocatedFunds, via _addSponsorship
+     **/
+    function _slash(address broker, uint amountWei, bool alsoKick) internal {
+        _reduceStakeBy(broker, amountWei);
+        if (alsoKick) {
+            _removeBroker(broker);
+            emit BrokerKicked(broker, amountWei);
         }
+        if (broker.code.length > 0) {
+            try ISlashListener(broker).onSlash(alsoKick) {} catch {}
+        }
+    }
+
+    /**
+     * Moves tokens from a broker's stake to "free funds" (that are not in unallocatedFunds!)
+     * @dev The caller MUST ensure those tokens are added to some other account, e.g. unallocatedFunds, via _addSponsorship
+     **/
+    function _reduceStakeBy(address broker, uint amountWei) internal {
+        // console.log("  internal _reduceStake", broker, amountWei);
+        require(amountWei <= globalData().stakedWei[broker], "error_cannotReduceStake");
+        globalData().stakedWei[broker] -= amountWei;
+        globalData().totalStakedWei -= amountWei;
+        moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onStakeChange.selector, broker, -int(amountWei)), "error_stakeDecreaseFailed");
         emit StakeUpdate(broker, globalData().stakedWei[broker], getAllocation(broker));
         emit BountyUpdate(globalData().totalStakedWei, globalData().unallocatedFunds, solventUntil(), globalData().brokerCount, isRunning());
     }
@@ -241,6 +265,7 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
         // send out both allocations and stake
         _withdraw(broker);
         require(token.transferAndCall(broker, stakedWei, "stake"), "error_transfer");
+        // console.log("removeBroker stake ->", broker, stakedWei);
 
         s.brokerCount -= 1;
         s.totalStakedWei -= stakedWei;
@@ -248,28 +273,9 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
         delete s.joinTimeOfBroker[broker];
 
         moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onLeave.selector, broker), "error_brokerLeaveFailed");
-        emit StakeUpdate(broker, s.stakedWei[broker], getAllocation(broker)); // TODO: stake and allocation will be zero after withdraw; write a test and then hardcode zeros
+        emit StakeUpdate(broker, 0, 0); // stake and allocation must be zero when the broker is gone
         emit BountyUpdate(globalData().totalStakedWei, globalData().unallocatedFunds, solventUntil(), globalData().brokerCount, isRunning());
         emit BrokerLeft(broker, stakedWei);
-    }
-
-    /**
-     * Slash moves tokens from a broker's stake to "free funds" (that are not in unallocatedFunds!)
-     * The caller should ensure those tokens are added to some other account, e.g. unallocatedFunds, via _addSponsorship
-     **/
-    function _slash(address broker, uint amountWei, bool alsoKick) internal {
-        require(amountWei <= globalData().stakedWei[broker], "error_cannotSlashStake");
-        globalData().stakedWei[broker] -= amountWei;
-        globalData().totalStakedWei -= amountWei;
-        moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onStakeDecrease.selector, broker, amountWei), "error_stakeDecreaseFailed");
-        if (alsoKick) {
-            _removeBroker(broker);
-        }
-        if (broker.code.length > 0) {
-            try ISlashListener(broker).onSlash(alsoKick) {} catch {}
-        }
-        emit StakeUpdate(broker, globalData().stakedWei[broker], getAllocation(broker));
-        emit BountyUpdate(globalData().totalStakedWei, globalData().unallocatedFunds, solventUntil(), globalData().brokerCount, isRunning());
     }
 
     /** Get allocations out, leave stake in */
@@ -282,10 +288,12 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
         require(stakedWei > 0, "error_brokerNotStaked");
 
         uint payoutWei = moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onWithdraw.selector, broker), "error_withdrawFailed");
+        // console.log("withdraw ->", broker, payoutWei);
         if (payoutWei > 0) {
-            emit StakeUpdate(broker, globalData().stakedWei[broker], getAllocation(broker)); // TODO: allocation will be zero after withdraw; write a test and then hardcode zeros
-            emit BountyUpdate(globalData().totalStakedWei, globalData().unallocatedFunds, solventUntil(), globalData().brokerCount, isRunning());
             require(token.transferAndCall(broker, payoutWei, "allocation"), "error_transfer");
+
+            emit StakeUpdate(broker, globalData().stakedWei[broker], 0); // allocation will be zero after withdraw (see test)
+            emit BountyUpdate(globalData().totalStakedWei, globalData().unallocatedFunds, solventUntil(), globalData().brokerCount, isRunning());
         }
     }
 
@@ -326,6 +334,11 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
     function voteOnFlag(address target, bytes32 voteData) external {
         require(address(kickPolicy) != address(0), "error_notSupported");
         moduleCall(address(kickPolicy), abi.encodeWithSelector(kickPolicy.onVote.selector, target, voteData), "error_kickPolicyFailed");
+    }
+
+    function getFlag(address target) external view returns (uint flagData) {
+        require(address(kickPolicy) != address(0), "error_notSupported");
+        return moduleGet(abi.encodeWithSelector(kickPolicy.getFlagData.selector, target, address(kickPolicy)), "error_kickPolicyFailed");
     }
 
     /////////////////////////////////////////

--- a/packages/network-contracts/contracts/BrokerEconomics/Bounty.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/Bounty.sol
@@ -174,7 +174,7 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
             s.totalStakedWei += amount;
 
             // re-calculate the cumulative earnings
-            moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onStakeIncrease.selector, broker, amount), "error_stakeIncreaseFailed");
+            moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onStakeChange.selector, broker, int(amount)), "error_stakeIncreaseFailed");
         }
         emit StakeUpdate(broker, s.stakedWei[broker], getAllocation(broker));
         emit BountyUpdate(s.totalStakedWei, s.unallocatedFunds, solventUntil(), s.brokerCount, isRunning());

--- a/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/AdminKickPolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/AdminKickPolicy.sol
@@ -20,12 +20,15 @@ contract AdminKickPolicy is IKickPolicy, Bounty {
     function onFlag(address broker, address) external {
         require(isAdmin(_msgSender()), "error_onlyAdmin");
         _slash(broker, 0, true);
-        emit BrokerKicked(broker, 0);
     }
 
     function onCancelFlag(address, address) external {
     }
 
     function onVote(address, bytes32) external {
+    }
+
+    function getFlagData(address) override external pure returns (uint flagData) {
+        return 0;
     }
 }

--- a/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/IAllocationPolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/IAllocationPolicy.sol
@@ -9,7 +9,6 @@ interface IAllocationPolicy {
     function onJoin(address broker) external;
     function onLeave(address broker) external;
     function onWithdraw(address broker) external returns (uint payoutWei);
-    function onStakeIncrease(address broker, uint amountWei) external;
-    function onStakeDecrease(address broker, uint decreaseAmount) external;
+    function onStakeChange(address broker, int stakeChangeWei) external;
     function onSponsor(address sponsor, uint amountWei) external;
 }

--- a/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/IKickPolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/IKickPolicy.sol
@@ -7,4 +7,5 @@ interface IKickPolicy {
     function onFlag(address broker, address brokerPool) external;
     function onCancelFlag(address broker, address brokerPool) external;
     function onVote(address broker, bytes32 voteData) external;
+    function getFlagData(address broker) external view returns (uint flagData);
 }

--- a/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/MinimumStakeJoinPolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/MinimumStakeJoinPolicy.sol
@@ -21,7 +21,6 @@ contract MinimumStakeJoinPolicy is IJoinPolicy, Bounty {
         localData().minimumStake = minimumStake;
     }
 
-
     // solc-ignore-next-line func-mutability
     function onJoin(address broker, uint256 amount) external {
         require(globalData().stakedWei[broker] + amount >= localData().minimumStake, "error_stakeUnderMinimum");

--- a/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/VoteKickPolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/VoteKickPolicy.sol
@@ -9,19 +9,31 @@ import "../BrokerPoolFactory.sol";
 // import "hardhat/console.sol";
 
 contract VoteKickPolicy is IKickPolicy, Bounty {
-    // struct LocalStorage {
-    // }
-    uint public constant FLAG_STAKE_WEI = 10 ether; // TODO: move to StreamrConstants?
-
+    // TODO: move to StreamrConstants?
+    uint public constant FLAG_STAKE_WEI = 10 ether;
     uint public constant REVIEWER_COUNT = 5;
+    uint public constant REVIEW_PERIOD_SECONDS = 1 days;
+    uint public constant VOTING_PERIOD_SECONDS = 1 hours;
+    uint public constant REVIEWER_REWARD_WEI = 1 ether;
+    uint public constant FLAGGER_REWARD_WEI = 1 ether;
+    uint public constant PROTECTION_SECONDS = 1 hours; // can't be flagged again right after a no-kick result
+
     mapping (address => address) public flaggerPoolAddress;
 
-    mapping (address => mapping (address => uint)) public reviewerState;
+    enum Reviewer {
+        NOT_SELECTED,
+        IS_SELECTED,
+        VOTED_KICK,
+        VOTED_NO_KICK,
+        IS_SELECTED_SECONDARY
+    }
+
+    mapping (address => uint) public flagTimestamp;
+    mapping (address => mapping (address => Reviewer)) public reviewerState;
     mapping (address => address[]) public reviewers;
     mapping (address => uint) public votesForKick;
-    mapping (address => address[]) public votersForKick;
     mapping (address => uint) public votesAgainstKick;
-    mapping (address => address[]) public votersAgainstKick;
+    mapping (address => uint) public protectionEndTimestamp; // can't be flagged again right after a no-kick result
 
     // 10% of the target's stake that is in the risk of being slashed upon kick
     mapping (address => uint) public targetStakeAtRiskWei;
@@ -36,11 +48,38 @@ contract VoteKickPolicy is IKickPolicy, Bounty {
     }
 
     /**
+     * Voting period starts after the review period ends
+     * During review period, the target still gets a chance to resume working; and flagger gets a chance to cancel the flag
+     **/
+    function canVote(address target) internal view returns (bool) {
+        return block.timestamp > flagTimestamp[target] + REVIEW_PERIOD_SECONDS; // false if flagTimestamp[broker] == 0
+    }
+
+    function voteEndTimestamp(address target) internal view returns (uint) {
+        return flagTimestamp[target] + REVIEW_PERIOD_SECONDS + VOTING_PERIOD_SECONDS;
+    }
+
+    function getFlagData(address broker) override external view returns (uint flagData) {
+        if (flagTimestamp[broker] == 0) {
+            return 0;
+        }
+        return uint(bytes32(abi.encodePacked(
+            uint160(flaggerPoolAddress[broker]),
+            uint32(flagTimestamp[broker]),
+            uint16(reviewers[broker].length),
+            uint16(votesForKick[broker]),
+            uint16(votesAgainstKick[broker])
+            // uint16()
+        )));
+    }
+
+    /**
      * Start flagging process
      */
     function onFlag(address target, address myBrokerPool) external {
+        require(flagTimestamp[target] == 0 && block.timestamp > protectionEndTimestamp[target], "error_cannotFlagAgain");
         require(BrokerPool(myBrokerPool).broker() == _msgSender(), "error_wrongBrokerPool"); // TODO replace with BrokerPoolInterfa
-        require(globalData().stakedWei[myBrokerPool] > 0, "error_notStaked");
+        require(globalData().stakedWei[myBrokerPool] > FLAG_STAKE_WEI, "error_notEnoughStake");
         require(globalData().stakedWei[target] > 0, "error_flagTargetNotStaked");
 
         // uint flagStakeWei = globalData().streamrConstants.flagStakeWei(); // TODO?
@@ -51,6 +90,8 @@ contract VoteKickPolicy is IKickPolicy, Bounty {
         targetStakeAtRiskWei[target] = globalData().stakedWei[target] / 10;
         globalData().committedStakeWei[target] += targetStakeAtRiskWei[target];
 
+        flagTimestamp[target] = block.timestamp;
+
         // only secondarily select peers that are in the same bounty as the flagging target
         address[REVIEWER_COUNT] memory sameBountyPeers;
         uint sameBountyPeerCount = 0;
@@ -58,19 +99,19 @@ contract VoteKickPolicy is IKickPolicy, Bounty {
         BrokerPoolFactory factory = BrokerPoolFactory(globalData().streamrConstants.brokerPoolFactory());
         uint brokerPoolCount = factory.deployedBrokerPoolsLength();
         // uint randomBytes = block.difficulty; // see https://github.com/ethereum/solidity/pull/13759
-        uint randomBytes = uint(uint160(target)) ^ 0x1235467890123457689012345678901234567890123546789012345678901234; // TODO temporary hack; polygon doesn't seem to support PREVRANDAO yet
+        bytes32 randomBytes = keccak256(abi.encode(target, brokerPoolCount)); // TODO temporary hack; polygon doesn't seem to support PREVRANDAO yet
         uint maxReviewersSearch = 20;
         assert(REVIEWER_COUNT <= 20); // to raise maxReviewersSearch, tweak >>= below, address gives 160 bits of "randomness"
         // assert(reviewerCount <= 32); // tweak >>= below, prevrandao gives 256 bits of randomness
 
         // primary selection: live peers that are not in the same bounty
         for (uint i = 0; i < maxReviewersSearch && reviewers[target].length < REVIEWER_COUNT; i++) {
-            randomBytes >>= 8;
-            uint index = randomBytes % brokerPoolCount;
+            randomBytes >>= 8; // if REVIEWER_COUNT > 20, replace this with keccak256(randomBytes) or smth
+            uint index = uint(randomBytes) % brokerPoolCount;
             BrokerPool pool = factory.deployedBrokerPools(index);
             address peer = pool.broker(); // TODO: via BrokerPool or directly?
             if (peer == _msgSender() || peer == BrokerPool(target).broker()
-                || reviewerState[target][peer] != 0) {
+                || reviewerState[target][peer] != Reviewer.NOT_SELECTED) {
                 // console.log(index, "skipping", peer);
                 continue;
             }
@@ -78,13 +119,13 @@ contract VoteKickPolicy is IKickPolicy, Bounty {
             if (globalData().stakedWei[address(pool)] > 0) {
                 if (sameBountyPeerCount + reviewers[target].length < REVIEWER_COUNT) {
                     sameBountyPeers[sameBountyPeerCount++] = peer;
-                    reviewerState[target][peer] = 10; // mark peer as "selected to the secondary selection list"
+                    reviewerState[target][peer] = Reviewer.IS_SELECTED_SECONDARY;
                 }
                 // console.log(index, "in same bounty", peer);
                 continue;
             }
             // console.log(index, "selecting", peer);
-            reviewerState[target][peer] = 1;
+            reviewerState[target][peer] = Reviewer.IS_SELECTED;
             emit ReviewRequest(peer, this, target);
             reviewers[target].push(peer);
         }
@@ -92,17 +133,17 @@ contract VoteKickPolicy is IKickPolicy, Bounty {
         // secondary selection: peers from the same bounty
         for (uint i = 0; i < sameBountyPeerCount; i++) {
             address peer = sameBountyPeers[i];
-            if (reviewerState[target][peer] == 1) {
+            if (reviewerState[target][peer] == Reviewer.IS_SELECTED) {
                 // console.log("already selected", peer);
                 continue;
             }
             if (reviewers[target].length >= REVIEWER_COUNT) {
-                reviewerState[target][peer] = 0; // mark peer as "not selected"
+                reviewerState[target][peer] = Reviewer.NOT_SELECTED;
                 // console.log("not selecting", peer);
                 continue;
             }
             // console.log("selecting from same bounty", peer);
-            reviewerState[target][peer] = 1;
+            reviewerState[target][peer] = Reviewer.IS_SELECTED;
             emit ReviewRequest(peer, this, target);
             reviewers[target].push(peer);
         }
@@ -110,81 +151,104 @@ contract VoteKickPolicy is IKickPolicy, Bounty {
     }
 
     /**
-     * Tally votes and trigger resolution
+     * Tally votes and trigger resolution when everyone has voted
+     * After voting period ends, anyone can trigger the resolution by calling this function
      */
     function onVote(address target, bytes32 voteData) external {
-        address voter = _msgSender(); // ?
-        require(reviewerState[target][voter] != 0, "error_reviewersOnly");
-        require(reviewerState[target][voter] != 2, "error_alreadyVoted");
-        uint vote = uint(voteData) & 0x1;
-        assert (vote == 0 || vote == 1);
-        reviewerState[target][voter] = 2;
-        // reviewers[target].push(voter);
-        uint result = 0;
-        uint reviewerCount = reviewers[target].length;
-        if (vote == 1) {
-            votesForKick[target]++;
-            votersForKick[target].push(voter);
-            if (votesForKick[target] > reviewerCount / 2) {
-                result = 1;
-            }
-        } else {
-            votesAgainstKick[target]++;
-            votersAgainstKick[target].push(voter);
-            if (votesAgainstKick[target] > reviewerCount / 2) {
-                result = 2;
-            }
+        require(canVote(target), "error_votingNotStarted");
+        if (block.timestamp > voteEndTimestamp(target)) {
+            _endVote(target);
+            return;
         }
-        if (result > 0) {
-            uint rewardWei = 1 ether; // globalData().streamrConstants.reviewerRewardWei();
-            address flagger = flaggerPoolAddress[target];
-            if (globalData().committedStakeWei[flagger] > 0) {
-                globalData().committedStakeWei[flagger] -= FLAG_STAKE_WEI;
-            }
-            globalData().committedStakeWei[target] -= targetStakeAtRiskWei[target];
-            uint slashingWei = targetStakeAtRiskWei[target];
-            if (result == 1) { // kick
-                uint flaggerRewardWei = 1 ether; // TODO: add to streamrConstants?
-                uint leftOverWei = slashingWei - flaggerRewardWei - rewardWei * reviewerCount;
-                _slash(target, slashingWei, true); // leftovers are added to sponsorship
-                payReviewers(votersForKick[target]);
-                _addSponsorship(address(this), leftOverWei);
-                emit BrokerKicked(target, slashingWei);
-                token.transfer(flagger, flaggerRewardWei);
-            } else if (result == 2) { // false flag, not kick
-                // uint flagStakeWei = globalData().streamrConstants.flagStakeWei(); // TODO?
-                uint leftOverWei = FLAG_STAKE_WEI - rewardWei * reviewerCount;
-                _slash(flagger, FLAG_STAKE_WEI, false);
-                payReviewers(votersAgainstKick[target]);
-                _addSponsorship(address(this), leftOverWei);
-            }
-            delete votesForKick[target];
-            delete votesAgainstKick[target];
-            delete votersForKick[target];
-            delete votersAgainstKick[target];
-            delete targetStakeAtRiskWei[target];
+        address voter = _msgSender(); // ?
+        require(reviewerState[target][voter] != Reviewer.NOT_SELECTED, "error_reviewersOnly");
+        require(reviewerState[target][voter] == Reviewer.IS_SELECTED, "error_alreadyVoted");
+        bool votedKick = uint(voteData) & 0x1 == 1;
+        reviewerState[target][voter] = votedKick ? Reviewer.VOTED_KICK : Reviewer.VOTED_NO_KICK;
+
+        // break ties by giving the first voter less weight
+        uint totalVotesBefore = votesForKick[target] + votesAgainstKick[target];
+        uint addVotes = totalVotesBefore == 0 ? 1 : 2;
+        if (votedKick) {
+            votesForKick[target] += addVotes;
+        } else {
+            votesAgainstKick[target] += addVotes;
+        }
+
+        // end voting early when everyone's vote is in
+        if (totalVotesBefore + addVotes + 1 == 2 * reviewers[target].length) {
+            _endVote(target);
         }
     }
 
+    function _endVote(address target) internal {
+        address flagger = flaggerPoolAddress[target];
+        uint reviewerCount = reviewers[target].length;
+        if (votesForKick[target] > votesAgainstKick[target]) {
+            uint slashingWei = targetStakeAtRiskWei[target];
+            _slash(target, slashingWei, true); // true = kick
+
+            // pay the flagger and those reviewers who voted correctly from the slashed stake
+            token.transfer(flagger, FLAGGER_REWARD_WEI);
+            slashingWei -= FLAGGER_REWARD_WEI;
+            for (uint i = 0; i < reviewerCount; i++) {
+                address reviewer = reviewers[target][i];
+                if (reviewerState[target][reviewer] == Reviewer.VOTED_KICK) {
+                    token.transfer(reviewer, REVIEWER_REWARD_WEI);
+                    slashingWei -= REVIEWER_REWARD_WEI;
+                }
+            }
+            _addSponsorship(address(this), slashingWei); // leftovers are added to sponsorship
+        } else {
+            // false flag, no kick; pay the reviewers who voted correctly from the flagger's stake
+            uint slashingWei = 0;
+            for (uint i = 0; i < reviewerCount; i++) {
+                address reviewer = reviewers[target][i];
+                if (reviewerState[target][reviewer] == Reviewer.VOTED_NO_KICK) {
+                    token.transfer(reviewer, REVIEWER_REWARD_WEI);
+                    slashingWei += REVIEWER_REWARD_WEI;
+                }
+            }
+            _slash(flagger, slashingWei, false);
+            protectionEndTimestamp[target] = block.timestamp + PROTECTION_SECONDS;
+        }
+        _cleanup(target);
+    }
+
+    /** Cancel the flag before voting starts => every reviewer gets paid */
     function onCancelFlag(address target, address myBrokerPool) external {
+        require(!canVote(target), "error_votingStarted");
         require(BrokerPool(myBrokerPool).broker() == _msgSender(), "error_wrongBrokerPool"); // TODO replace with BrokerPoolInterfa
         require(flaggerPoolAddress[target] == myBrokerPool, "error_notFlagger");
-        payReviewers(votersForKick[target]);
-        payReviewers(votersAgainstKick[target]);
-        globalData().committedStakeWei[flaggerPoolAddress[target]] -= FLAG_STAKE_WEI;
-        globalData().committedStakeWei[target] -= targetStakeAtRiskWei[target];
-        delete votesForKick[target];
-        delete votesAgainstKick[target];
-        delete votersForKick[target];
-        delete votersAgainstKick[target];
-        delete targetStakeAtRiskWei[target];
+        uint rewardWei = 1 ether; // TODO: add to streamrConstants?
+        uint reviewerCount = reviewers[target].length;
+        for (uint i = 0; i < reviewerCount; i++) {
+            address reviewer = reviewers[target][i];
+            // console.log("paying reviewer", reviewer);
+            token.transfer(reviewer, rewardWei);
+        }
+        _cleanup(target);
     }
 
-    function payReviewers(address[] memory votersToPay) internal {
-        uint rewardWei = 1 ether; // TODO: add to streamrConstants?
-        for (uint i = 0; i < votersToPay.length; i++) {
-            // console.log("paying reviewer %s", votersToPay[i]);
-            token.transfer(votersToPay[i], rewardWei);
+    /** Remove stake commitments and clear flag data */
+    function _cleanup(address target) internal {
+        // flagger might already have been kicked
+        address flagger = flaggerPoolAddress[target];
+        if (globalData().committedStakeWei[flagger] > 0) {
+            globalData().committedStakeWei[flagger] -= FLAG_STAKE_WEI;
         }
+        globalData().committedStakeWei[target] -= targetStakeAtRiskWei[target];
+
+        uint reviewerCount = reviewers[target].length;
+        for (uint i = 0; i < reviewerCount; i++) {
+            address reviewer = reviewers[target][i];
+            delete reviewerState[target][reviewer];
+        }
+        delete reviewers[target];
+        delete flaggerPoolAddress[target];
+        delete flagTimestamp[target];
+        delete targetStakeAtRiskWei[target];
+        delete votesForKick[target];
+        delete votesAgainstKick[target];
     }
 }

--- a/packages/network-contracts/contracts/BrokerEconomics/testcontracts/TestAllocationPolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/testcontracts/TestAllocationPolicy.sol
@@ -66,19 +66,12 @@ contract TestAllocationPolicy is IAllocationPolicy, Bounty {
     /**
      * When stake changes, effectively do a leave + join, resetting the CE for this broker
      */
-    function onStakeIncrease(address, uint) external view {
+    function onStakeChange(address, int) external view {
         if (localData().failOnIncrease) {
-            require(false, "test_onStakeIncrease");
+            require(false, "test_onStakeChange");
         } else if (localData().failEmptyOnIncrease) {
             require(false); // solhint-disable-line reason-string
         }
-    }
-    function onStakeDecrease(address, uint) external view {
-        // if (localData().failOnDecrease) {
-        //     require(false, "test_onStakeDecrease");
-        // } else if (localData().failEmptyOnDecrease) {
-        //     require(false); // solhint-disable-line reason-string
-        // }
     }
 
     function onWithdraw(address) external pure returns (uint payoutWei) {

--- a/packages/network-contracts/contracts/BrokerEconomics/testcontracts/TestKickPolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/testcontracts/TestKickPolicy.sol
@@ -31,9 +31,13 @@ contract TestKickPolicy is IKickPolicy, Bounty {
         console.log("onkick");
         require(isAdmin(_msgSender()), "error_onlyAdmin");
         _slash(broker, 0, true);
-        emit BrokerKicked(broker, 0);
     }
 
     function onVote(address broker, bytes32 voteData) external {
+    }
+
+    // solhint-disable-next-line no-unused-vars
+    function getFlagData(address broker) override external pure returns (uint flagData) {
+        return 0;
     }
 }

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/AdminKickPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/AdminKickPolicy.test.ts
@@ -3,7 +3,7 @@ import { ethers } from "hardhat"
 import { utils, Wallet } from "ethers"
 
 import { deployTestContracts, TestContracts } from "../deployTestContracts"
-import { advanceToTimestamp, getBlockTimestamp, log } from "../utils"
+import { advanceToTimestamp, getBlockTimestamp } from "../utils"
 
 import { deployBountyContract } from "../deployBountyContract"
 

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/AdminKickPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/AdminKickPolicy.test.ts
@@ -13,32 +13,27 @@ describe("AdminKickPolicy", (): void => {
     let admin: Wallet
     let broker: Wallet
     let broker2: Wallet
-    let broker3: Wallet
 
     let contracts: TestContracts
     before(async (): Promise<void> => {
-        [admin, broker, broker2, broker3] = await ethers.getSigners() as unknown as Wallet[]
+        [admin, broker, broker2] = await ethers.getSigners() as unknown as Wallet[]
         contracts = await deployTestContracts(admin)
 
         const { token } = contracts
         await (await token.mint(admin.address, parseEther("1000000"))).wait()
-        await (await token.transfer(await broker.getAddress(), parseEther("100000"))).wait()
-        await (await token.transfer(broker2.address, parseEther("100000"))).wait()
-        await (await token.transfer(broker3.address, parseEther("100000"))).wait()
     })
 
     it("doesn't penalize a kicked broker like it penalizes a leaving broker", async function(): Promise<void> {
         // time:        0 ... 100 ... 200 ... 300
         // join/leave: +b1    +b2   b1 kick  b2 leave
-        // broker1:       100  +  50                = 150 - penalty 1wei = 150 - 1wei
+        // broker1:       100  +  50                = 150
         // broker2:               50   +  100       = 150 - penalty 100  = 50
         const { token } = contracts
+        await (await token.mint(broker.address, parseEther("1000"))).wait()
+        await (await token.mint(broker2.address, parseEther("1000"))).wait()
         const bounty = await deployBountyContract(contracts, { penaltyPeriodSeconds: 1000, adminKickInsteadOfVoteKick: true })
-
         await bounty.sponsor(parseEther("10000"))
 
-        const balanceBefore = await token.balanceOf(await broker.getAddress())
-        const balanceBefore2 = await token.balanceOf(broker2.address)
         const timeAtStart = await getBlockTimestamp()
 
         await advanceToTimestamp(timeAtStart, "broker 1 joins")
@@ -46,8 +41,6 @@ describe("AdminKickPolicy", (): void => {
 
         await advanceToTimestamp(timeAtStart + 100, "broker 2 joins")
         await (await token.connect(broker2).transferAndCall(bounty.address, parseEther("1000"), broker2.address)).wait()
-
-        log("IsAdmin %o", await bounty.isAdmin(admin.address))
 
         // event BrokerKicked(address indexed broker, uint slashedWei);
         const brokerCountBeforeKick = await bounty.getBrokerCount()
@@ -60,13 +53,10 @@ describe("AdminKickPolicy", (): void => {
         await advanceToTimestamp(timeAtStart + 300, "broker 2 leaves and gets slashed")
         await (await bounty.connect(broker2).leave()).wait()
 
-        const balanceChange = (await token.balanceOf(await broker.getAddress())).sub(balanceBefore)
-        const balanceChange2 = (await token.balanceOf(broker2.address)).sub(balanceBefore2)
-
         expect(brokerCountBeforeKick.toString()).to.equal("2")
         expect(brokerCountAfterKick.toString()).to.equal("1")
-        expect(formatEther(balanceChange)).to.equal("150.0")
-        expect(formatEther(balanceChange2)).to.equal("50.0")
+        expect(formatEther(await token.balanceOf(broker.address))).to.equal("1150.0")
+        expect(formatEther(await token.balanceOf(broker2.address))).to.equal("1050.0")
     })
 
     it("doesn't allow non-admins to kick", async function(): Promise<void> {

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/DefaultLeavePolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/DefaultLeavePolicy.test.ts
@@ -28,12 +28,16 @@ describe("DefaultLeavePolicy", (): void => {
         await (await token.transfer(broker2.address, parseEther("100000"))).wait()
     })
 
-    it("FAILS if penaltyPeriodSeconds is higher than the global max", async function(): Promise<void> {
+    it("FAILS to deploy if penaltyPeriodSeconds is higher than the global max", async function(): Promise<void> {
         await expect(deployBountyContract(contracts, { minBrokerCount: 2, penaltyPeriodSeconds: 2678000 }))
             .to.be.revertedWith("error_penaltyPeriodTooLong")
     })
 
-    it("penalizes only from the broker that leaves early while bounty is running", async function(): Promise<void> {
+    it("penalizes only the broker that leaves early while bounty is running", async function(): Promise<void> {
+        // time:        0 ... 100 ... 300 ... 400
+        // join/leave: +b1    +b2     -b1     -b2
+        // earnings b1: 0       0     100
+        // earnings b2:         0     100       0
         const { token } = contracts
         const bounty = await deployBountyContract(contracts, { minBrokerCount: 2, penaltyPeriodSeconds: 1000 })
         expect(!await bounty.isRunning())
@@ -47,22 +51,22 @@ describe("DefaultLeavePolicy", (): void => {
         const balanceBefore2 = await token.balanceOf(broker2.address)
         const timeAtStart = await getBlockTimestamp()
 
-        await advanceToTimestamp(timeAtStart)
+        await advanceToTimestamp(timeAtStart, "broker 1 joins, bounty still not started")
         await (await token.connect(broker).transferAndCall(bounty.address, parseEther("1000"), broker.address)).wait()
         expect(!await bounty.isRunning())
         expect(await bounty.isFunded())
 
-        await advanceToTimestamp(timeAtStart + 100, "broker 2 joins, both will earn 100")
+        await advanceToTimestamp(timeAtStart + 100, "broker 2 joins, bounty starts")
         await (await token.connect(broker2).transferAndCall(bounty.address, parseEther("1000"), broker2.address)).wait()
         expect(await bounty.isRunning())
         expect(await bounty.isFunded())
 
-        await advanceToTimestamp(timeAtStart + 300, "broker 1 leaves while bounty is running, loses 10% of 1000 = 100")
+        await advanceToTimestamp(timeAtStart + 300, "broker 1 leaves while bounty is running, bounty stops")
         await (await bounty.connect(broker).leave()).wait()
         expect(!await bounty.isRunning())
         expect(await bounty.isFunded())
 
-        await advanceToTimestamp(timeAtStart + 400, "broker 2 leaves when bounty is stopped, keeps stake")
+        await advanceToTimestamp(timeAtStart + 400, "broker 2 leaves when bounty is stopped")
         await (await bounty.connect(broker2).leave()).wait()
         expect(!await bounty.isRunning())
         expect(await bounty.isFunded())
@@ -70,8 +74,8 @@ describe("DefaultLeavePolicy", (): void => {
         const balanceChange = (await token.balanceOf(broker.address)).sub(balanceBefore)
         const balanceChange2 = (await token.balanceOf(broker2.address)).sub(balanceBefore2)
 
-        expect(formatEther(balanceChange)).to.equal("0.0")      // == 100 - 100
-        expect(formatEther(balanceChange2)).to.equal("100.0")   // == 100 - 0
+        expect(formatEther(balanceChange)).to.equal("0.0") // loses 10% of 1000 = 100, gets 900 back + 100 earnings = 1000 same as staked
+        expect(formatEther(balanceChange2)).to.equal("100.0") // keeps stake, gets 1000 back + 100 earnings = 1100
     })
 
     it("doesn't penalize a broker that leaves after the leave period (even when contract is running)", async function(): Promise<void> {

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/StakeWeightedAllocationPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/StakeWeightedAllocationPolicy.test.ts
@@ -33,8 +33,8 @@ describe("StakeWeightedAllocationPolicy", (): void => {
         const balanceBefore = await token.balanceOf(broker.address)
         const timeAtStart = await getBlockTimestamp()
 
+        // join tx actually happens at timeAtStart + 1
         await advanceToTimestamp(timeAtStart, "broker joins")
-        // this tx this happens at timeAtStart + 1
         await (await token.connect(broker).transferAndCall(bounty.address, parseEther("1000"), broker.address)).wait()
         const allocationAfterJoin = await bounty.getAllocation(broker.address)
         const stakeAfterJoin = await bounty.getStake(broker.address)


### PR DESCRIPTION
- don't call _slash if no leave penalty
- also implemented the +1/+2 votes idea to avoid ties (ETH-457)
- onStakeIncrease + onStakeDecrease => onStakeChange
- StakeUpdate event TODOs implemented (added tests into Bounty.test.ts)
- VoteKickPolicy now has review period and voting period (no "timeouts" except maybe if no one voted?)
- DRYed up some calculateAllocation overlaps in StakeWeightedAllocationPolicy