### PR TITLE
ETH-458: even if flagger gets kicked before flag is resolved, now reviewers will get correctly paid

### DIFF
--- a/packages/network-contracts/contracts/BrokerEconomics/Bounty.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/Bounty.sol
@@ -57,9 +57,9 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
     struct GlobalStorage {
         StreamrConstants streamrConstants;
         mapping(address => uint) stakedWei; // how much each broker has staked, if 0 broker is considered not part of bounty
-        mapping(address => uint) committedStakeWei; // how much can not be unstaked (during e.g. flagging)
         mapping(address => uint) joinTimeOfBroker;
-        uint committedFundsWei;
+        mapping(address => uint) committedStakeWei; // how much can not be unstaked (during e.g. flagging)
+        uint committedFundsWei; // committedStakeWei that has been forfeited but still needs to be tracked to e.g. pay the flag reviewers
         uint32 brokerCount;
         uint32 minBrokerCount;
         uint32 minHorizonSeconds;
@@ -147,35 +147,33 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
         }
     }
 
-    /** Stake by first calling ERC20.approve(bounty.address, amountTokenWei) then this function */
-    function stake(address broker, uint amountTokenWei) external {
-        token.transferFrom(_msgSender(), address(this), amountTokenWei);
-        _stake(broker, amountTokenWei);
+    /** Stake by first calling DATA.approve(bounty.address, amountWei) then this function */
+    function stake(address broker, uint amountWei) external {
+        token.transferFrom(_msgSender(), address(this), amountWei);
+        _stake(broker, amountWei);
     }
 
-    function _stake(address broker, uint amount) internal {
-        // console.log("join/stake at ", block.timestamp);
-        require(amount > 0, "error_cannotStakeZero");
+    function _stake(address broker, uint amountWei) internal {
+        // console.log("join/stake at ", block.timestamp, broker, amountWei);
+        require(amountWei > 0, "error_cannotStakeZero");
         GlobalStorage storage s = globalData();
         if (s.stakedWei[broker] == 0) {
-           // console.log("Broker joins and stakes", broker, amount);
+           // console.log("Broker joins and stakes", broker, amountWei);
             for (uint i = 0; i < joinPolicies.length; i++) {
                 IJoinPolicy joinPolicy = joinPolicies[i];
-                moduleCall(address(joinPolicy), abi.encodeWithSelector(joinPolicy.onJoin.selector, broker, amount), "error_joinPolicyOnJoin");
+                moduleCall(address(joinPolicy), abi.encodeWithSelector(joinPolicy.onJoin.selector, broker, amountWei), "error_joinPolicyOnJoin");
             }
-            s.stakedWei[broker] += amount;
+            s.stakedWei[broker] += amountWei;
             s.brokerCount += 1;
-            s.totalStakedWei += amount;
+            s.totalStakedWei += amountWei;
             s.joinTimeOfBroker[broker] = block.timestamp; // solhint-disable-line not-rely-on-time
             moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onJoin.selector, broker), "error_allocationPolicyOnJoin");
             emit BrokerJoined(broker);
         } else {
-           // console.log("Broker already joined, increasing stake", broker, amount);
-            s.stakedWei[broker] += amount;
-            s.totalStakedWei += amount;
-
-            // re-calculate the cumulative earnings
-            moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onStakeChange.selector, broker, int(amount)), "error_stakeIncreaseFailed");
+           // console.log("Broker already joined, increasing stake", broker, amountWei);
+            s.stakedWei[broker] += amountWei;
+            s.totalStakedWei += amountWei;
+            moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onStakeChange.selector, broker, int(amountWei)), "error_stakeIncreaseFailed");
         }
         emit StakeUpdate(broker, s.stakedWei[broker], getAllocation(broker));
         emit BountyUpdate(s.totalStakedWei, s.unallocatedFunds, solventUntil(), s.brokerCount, isRunning());
@@ -306,16 +304,16 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
         }
     }
 
-    /** Sponsor a stream by first calling ERC20.approve(agreement.address, amountTokenWei) then this function */
-    function sponsor(uint amountTokenWei) external {
-        token.transferFrom(_msgSender(), address(this), amountTokenWei);
-        _addSponsorship(_msgSender(), amountTokenWei);
+    /** Sponsor a stream by first calling DATA.approve(agreement.address, amountWei) then this function */
+    function sponsor(uint amountWei) external {
+        token.transferFrom(_msgSender(), address(this), amountWei);
+        _addSponsorship(_msgSender(), amountWei);
     }
 
-    function _addSponsorship(address sponsorAddress, uint amountTokenWei) internal {
+    function _addSponsorship(address sponsorAddress, uint amountWei) internal {
         // TODO: sweep also unaccounted tokens into unallocated funds?
-        moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onSponsor.selector, sponsorAddress, amountTokenWei), "error_sponsorFailed");
-        globalData().unallocatedFunds += amountTokenWei;
+        moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onSponsor.selector, sponsorAddress, amountWei), "error_sponsorFailed");
+        globalData().unallocatedFunds += amountWei;
         emit BountyUpdate(globalData().totalStakedWei, globalData().unallocatedFunds, solventUntil(), globalData().brokerCount, isRunning());
     }
 

--- a/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/VoteKickPolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/VoteKickPolicy.sol
@@ -187,59 +187,84 @@ contract VoteKickPolicy is IKickPolicy, Bounty {
 
     function _endVote(address target) internal {
         address flagger = flaggerAddress[target];
+        bool flaggerWasKicked = globalData().stakedWei[flagger] == 0;
         uint reviewerCount = reviewers[target].length;
         if (votesForKick[target] > votesAgainstKick[target]) {
             uint slashingWei = targetStakeAtRiskWei[target];
             _slash(target, slashingWei, true); // true = kick
 
             // pay the flagger and those reviewers who voted correctly from the slashed stake
-            token.transfer(flagger, FLAGGER_REWARD_WEI);
-            slashingWei -= FLAGGER_REWARD_WEI;
+            if (!flaggerWasKicked) {
+                token.transfer(flagger, FLAGGER_REWARD_WEI);
+                slashingWei -= FLAGGER_REWARD_WEI;
+            }
             for (uint i = 0; i < reviewerCount; i++) {
                 address reviewer = reviewers[target][i];
                 if (reviewerState[target][reviewer] == Reviewer.VOTED_KICK) {
-                    token.transfer(BrokerPool(reviewer).broker(), REVIEWER_REWARD_WEI);
+                    token.transfer(BrokerPool(reviewer).broker(), REVIEWER_REWARD_WEI); // TODO: pay broker or BrokerPool?
                     slashingWei -= REVIEWER_REWARD_WEI;
                 }
             }
             _addSponsorship(address(this), slashingWei); // leftovers are added to sponsorship
         } else {
-            // false flag, no kick; pay the reviewers who voted correctly from the flagger's stake
+            // false flag, no kick; pay the reviewers who voted correctly from the flagger's stake, return the leftovers to the flagger
             protectionEndTimestamp[target] = block.timestamp + PROTECTION_SECONDS; // solhint-disable-line not-rely-on-time
-            uint slashingWei = 0;
+            uint rewardsWei = 0;
             for (uint i = 0; i < reviewerCount; i++) {
                 address reviewer = reviewers[target][i];
                 if (reviewerState[target][reviewer] == Reviewer.VOTED_NO_KICK) {
-                    token.transfer(BrokerPool(reviewer).broker(), REVIEWER_REWARD_WEI);
-                    slashingWei += REVIEWER_REWARD_WEI;
+                    token.transfer(BrokerPool(reviewer).broker(), REVIEWER_REWARD_WEI); // TODO: pay broker or BrokerPool?
+                    rewardsWei += REVIEWER_REWARD_WEI;
                 }
             }
-            _slash(flagger, slashingWei, false);
+            if (flaggerWasKicked) {
+                uint leftoverWei = FLAG_STAKE_WEI - rewardsWei;
+                _addSponsorship(address(this), leftoverWei); // flagger had been kicked, so the remaining flagstake is added to sponsorship
+            } else {
+                _slash(flagger, rewardsWei, false); // just slash enough to cover the rewards, the rest will be uncommitted = released
+            }
         }
-        _cleanup(target);
+        _cleanup(target); // TODO: if cancelFlag is removed, inline the _cleanup and esp. the delete reviewerState loop
     }
 
     /* solhint-enable reentrancy */
 
-    /** Cancel the flag before voting starts => every reviewer gets paid */
+    /**
+     * Cancel the flag before voting starts => every reviewer gets paid
+     * If a reviewer was kicked, we assume his flags may have been bad, too => can be cancelled by anyone
+     **/
     function onCancelFlag(address target) external {
+        address flagger = flaggerAddress[target];
+        bool flaggerWasKicked = globalData().stakedWei[flagger] == 0;
         require(!canVote(target), "error_votingStarted");
-        require(flaggerAddress[target] == _msgSender(), "error_notFlagger");
-        uint rewardWei = 1 ether; // TODO: add to streamrConstants?
+        require(flagger == _msgSender() || flaggerWasKicked, "error_notFlagger");
+        // TODO: protection after cancel can be abused to shield freeriders, because ANYONE in bounty can flag then cancel
+        protectionEndTimestamp[target] = block.timestamp + PROTECTION_SECONDS; // solhint-disable-line not-rely-on-time
         uint reviewerCount = reviewers[target].length;
+        uint rewardsWei = reviewerCount * REVIEWER_REWARD_WEI;
+        if (flaggerWasKicked) {
+            uint leftoverWei = FLAG_STAKE_WEI - rewardsWei;
+            _addSponsorship(address(this), leftoverWei); // flagger had been kicked, so the remaining flagstake is added to sponsorship
+        } else {
+            _slash(flagger, rewardsWei, false); // just slash enough to cover the rewards, the rest will be uncommitted = released
+        }
         for (uint i = 0; i < reviewerCount; i++) {
             address reviewer = reviewers[target][i];
-            token.transfer(BrokerPool(reviewer).broker(), rewardWei);
+            token.transfer(BrokerPool(reviewer).broker(), REVIEWER_REWARD_WEI); // TODO: pay broker or BrokerPool?
         }
         _cleanup(target);
     }
 
+    // TODO: if cancelFlag is removed, inline the _cleanup and esp. the delete reviewerState loop
     /** Remove stake commitments and clear flag data */
     function _cleanup(address target) internal {
         // flagger might already have been kicked
         address flagger = flaggerAddress[target];
-        if (globalData().committedStakeWei[flagger] > 0) {
+        if (globalData().committedStakeWei[flagger] >= FLAG_STAKE_WEI) {
             globalData().committedStakeWei[flagger] -= FLAG_STAKE_WEI;
+        } else {
+            // flagger was kicked during the flag
+            globalData().committedFundsWei -= FLAG_STAKE_WEI;
         }
         globalData().committedStakeWei[target] -= targetStakeAtRiskWei[target];
 

--- a/packages/network-contracts/contracts/BrokerEconomics/BrokerPool.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BrokerPool.sol
@@ -253,7 +253,7 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
      */
     function forceUnstake(Bounty bounty, uint maxQueuePayoutIterations) external {
         // onlyBroker check happens only if grace period hasn't passed yet
-        if (block.timestamp < undelegationQueue[queuePayoutIndex].timestamp + maxQueueSeconds) {
+        if (block.timestamp < undelegationQueue[queuePayoutIndex].timestamp + maxQueueSeconds) { // solhint-disable-line not-rely-on-time
             require(msg.sender == globalData().broker, "error_onlyBroker");
         }
 


### PR DESCRIPTION
also VoteKickPolicy test cleanups

in smart contracts, uniformly `amountWei` instead of `amountTokenWei` or `amount`