### PR TITLE
force docker to build subgraph deploy images in AMD64 platform

### DIFF
--- a/packages/network-subgraphs/README.md
+++ b/packages/network-subgraphs/README.md
@@ -8,7 +8,7 @@ Run `streamr-docker-dev start deploy-network-subgraphs`
 
 The container and thus image that initially compiles and pushes the subgraph to the graph node
 can be recreated with the Dockerfile. To do so:
-- build image: `npm run docker:build` OR `docker build . -t streamr/deploy-network-subgraphs:dev`
+- build image: `npm run docker:build` OR `docker buildx build --platform linux/AMD64 . -t streamr/deploy-network-subgraphs:dev`
 - publish image: `npm run docker:publish` OR `docker push streamr/deploy-network-subgraphs:dev`
 
 ## Prod deployment to the hosted service

--- a/packages/network-subgraphs/package.json
+++ b/packages/network-subgraphs/package.json
@@ -8,7 +8,7 @@
     "codegen": "graph codegen",
     "graphbuild": "graph build",
     "build": "./copyAbisFromContractsPackage.sh && npm run codegen && npm run graphbuild",
-    "docker:build": "npm run build && docker build . -t streamr/deploy-network-subgraphs:dev",
+    "docker:build": "npm run build && docker buildx build --platform linux/AMD64 . -t streamr/deploy-network-subgraphs:dev",
     "docker:publish": "docker image push streamr/deploy-network-subgraphs:dev",
     "create-docker-dev": "graph create streamr-dev/network-subgraphs --node http://streamr-dev-thegraph-node:8020",
     "deploy-docker-dev": "graph deploy streamr-dev/network-subgraphs --version-label v0.0.1 --ipfs http://streamr-dev-ipfs:5001 --node http://streamr-dev-thegraph-node:8020",


### PR DESCRIPTION
force docker to build subgraph deploy images in AMD64 platform instead of arm64 (on a apple silicon mac)