### PR TITLE
ETH-435: renamings, removed GlobalStorage

### DIFF
--- a/packages/network-contracts/contracts/BrokerEconomics/Bounty.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/Bounty.sol
@@ -29,19 +29,19 @@ import "./StreamrConfig.sol";
  * The tokens held by `Bounty` are tracked in several accounts:
  * - totalStakedWei: total amount of tokens staked by all brokers
  *  -> each broker has their `stakedWei`, part of which can be `committedStakeWei` if there are flags on/by them
- * - unallocatedFunds: part of the sponsorship that hasn't been paid out yet
+ * - unallocatedWei: part of the sponsorship that hasn't been paid out yet
  *  -> decides the `solventUntil` timestamp: more unallocated funds left means the `Bounty` is solvent for a longer time
  * - committedFundsWei: forfeited stakes that were committed to a flag by a past broker who `forceUnstake`d (or was kicked)
  *  -> should be zero when there are no active flags
  *
  * @dev It's important that whenever tokens are moved out (or unaccounted tokens detected) that they be accounted for
- *  either via _stake/_slash (to/from stake) or _addSponsorship (to unallocatedFunds)
+ *  either via _stake/_slash (to/from stake) or _addSponsorship (to unallocatedWei)
  */
 contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, AccessControlUpgradeable { //}, ERC2771Context {
 
-    event StakeUpdate(address indexed broker, uint stakedWei, uint allocatedWei);
+    event StakeUpdate(address indexed broker, uint stakedWei, uint allocatedWei); // TODO change: allocatedWei -> earningsWei
     event MetadataUpdate(string metadata);
-    event BountyUpdate(uint totalStakeWei, uint unallocatedWei, uint projectedInsolvencyTime, uint32 brokerCount, bool isRunning);
+    event BountyUpdate(uint totalStakeWei, uint unallocatedWei, uint projectedInsolvencyTime, uint32 brokerCount, bool isRunning); // TODO: change uint32 -> uint
     event FlagUpdate(address indexed flagger, address target, uint targetCommittedStake, uint result);
     event BrokerJoined(address indexed broker);
     event BrokerLeft(address indexed broker, uint returnedStakeWei);
@@ -56,6 +56,7 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant TRUSTED_FORWARDER_ROLE = keccak256("TRUSTED_FORWARDER_ROLE");
 
+    StreamrConfig public streamrConfig;
     IERC677 public token;
     IJoinPolicy[] public joinPolicies;
     IAllocationPolicy public allocationPolicy;
@@ -64,49 +65,23 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
     string public streamId;
     string public metadata;
 
-    // TODO: remove GlobalStorage, also remove the below getters functions
-    // storage variables available to all modules
-    struct GlobalStorage {
-        StreamrConfig streamrConfig;
-        mapping(address => uint) stakedWei; // how much each broker has staked, if 0 broker is considered not part of bounty
-        mapping(address => uint) joinTimeOfBroker;
-        mapping(address => uint) committedStakeWei; // how much can not be unstaked (during e.g. flagging)
-        uint committedFundsWei; // committedStakeWei that has been forfeited but still needs to be tracked to e.g. pay the flag reviewers
-        uint32 brokerCount;
-        uint32 minBrokerCount;
-        uint32 minHorizonSeconds;
-        uint totalStakedWei;
-        uint unallocatedFunds;
-        uint minimumStakeWei;
-    }
-
-    function globalData() internal pure returns(GlobalStorage storage data) {
-        bytes32 storagePosition = keccak256("bounty.storage.GlobalStorage");
-        assembly { data.slot := storagePosition } // solhint-disable-line no-inline-assembly
-    }
-
-    function getUnallocatedWei() public view returns(uint) {
-        return globalData().unallocatedFunds;
-    }
-
-    function totalStakedWei() public view returns(uint) {
-        return globalData().totalStakedWei;
-    }
-
-    function getBrokerCount() public view returns(uint) {
-        return globalData().brokerCount;
-    }
+    mapping(address => uint) public stakedWei; // how much each broker has staked, if 0 broker is considered not part of bounty
+    mapping(address => uint) public joinTimeOfBroker;
+    mapping(address => uint) public committedStakeWei; // how much can not be unstaked (during e.g. flagging)
+    uint public committedFundsWei; // committedStakeWei that has been forfeited but still needs to be tracked to e.g. pay the flag reviewers
+    uint public brokerCount;
+    uint public minBrokerCount;
+    uint public minHorizonSeconds;
+    uint public totalStakedWei;
+    uint public unallocatedWei;
+    uint public minimumStakeWei;
 
     function isAdmin(address a) public view returns(bool) {
         return hasRole(ADMIN_ROLE, a);
     }
 
-    function getStake(address broker) external view returns (uint) {
-        return globalData().stakedWei[broker];
-    }
-
     function getMyStake() public view returns (uint) {
-        return globalData().stakedWei[_msgSender()];
+        return stakedWei[_msgSender()];
     }
 
     /**
@@ -114,9 +89,8 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
      *   hence there is an individual limit for reduceStakeTo.
      * When joining, committed stake is zero, so the it's the same minimumStakeWei for everyone.
      */
-    function minimumStakeOf(address broker) public view returns (uint minimumStakeWei) {
-        GlobalStorage storage s = globalData();
-        return max(s.committedStakeWei[broker], s.minimumStakeWei);
+    function minimumStakeOf(address broker) public view returns (uint) {
+        return max(committedStakeWei[broker], minimumStakeWei);
     }
 
     /**
@@ -125,7 +99,7 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
      * See https://hackmd.io/i8M8iFQLSIa9RbDn-d5Szg?view#Mechanisms
      */
     function isRunning() public view returns (bool) {
-        return globalData().brokerCount >= globalData().minBrokerCount;
+        return brokerCount >= minBrokerCount;
     }
 
     /**
@@ -133,23 +107,22 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
      * DefaultLeavePolicy states brokers are free to leave an underfunded bounty
      */
     function isFunded() public view returns (bool) {
-        return solventUntil() > block.timestamp + globalData().minHorizonSeconds; // solhint-disable-line not-rely-on-time
+        return solventUntil() > block.timestamp + minHorizonSeconds; // solhint-disable-line not-rely-on-time
     }
 
     constructor() ERC2771ContextUpgradeable(address(0x0)) {}
 
+    /**
+     * @param initParams array of: [0] initialMinimumStakeWei, [1] initialMinHorizonSeconds, [2] initialMinBrokerCount, [3] weiPerSecond
+     */
     function initialize(
         string calldata streamId_,
         string calldata metadata_,
-        StreamrConfig streamrConfig,
+        StreamrConfig globalStreamrConfig,
         address newOwner,
         address tokenAddress,
-        // uint initialMinimumStakeWei,
-        uint[4] calldata initParams, // [initialMinimumStakeWei, initialMinHorizonSeconds, initialMinBrokerCount, allocationPolicyParam]
-        // uint32 initialMinHorizonSeconds,
-        // uint32 initialMinBrokerCount,
+        uint[4] calldata initParams,
         IAllocationPolicy initialAllocationPolicy
-        // uint allocationPolicyParam
     ) public initializer {
         require(initParams[2] > 0, "error_minBrokerCountZero");
         require(initParams[0] > 0, "error_minimumStakeZero");
@@ -160,10 +133,10 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
         token = IERC677(tokenAddress);
         streamId = streamId_;
         metadata = metadata_;
-        globalData().minimumStakeWei = initParams[0];
-        globalData().minHorizonSeconds = uint32(initParams[1]);
-        globalData().minBrokerCount = uint32(initParams[2]);
-        globalData().streamrConfig = StreamrConfig(streamrConfig);
+        minimumStakeWei = initParams[0];
+        minHorizonSeconds = uint32(initParams[1]);
+        minBrokerCount = uint32(initParams[2]);
+        streamrConfig = globalStreamrConfig;
         setAllocationPolicy(initialAllocationPolicy, initParams[3]);
     }
 
@@ -174,14 +147,14 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
     function onTokenTransfer(address sender, uint amount, bytes calldata data) external {
         require(_msgSender() == address(token), "error_onlyDATAToken");
         if (data.length == 20) {
-            // shift 20 bytes (= 160 bits) to end of uint256 to make it an address => shift by 256 - 160 = 96
+            // shift the 20 address bytes (= 160 bits) to end of uint256 to populate an address variable => shift by 256 - 160 = 96
             // (this is what abi.encodePacked would produce)
             address stakeBeneficiary;
             assembly { stakeBeneficiary := shr(96, calldataload(data.offset)) } // solhint-disable-line no-inline-assembly
             _stake(stakeBeneficiary, amount);
         } else if (data.length == 32) {
-            // assume the address was encoded by converting address -> uint -> bytes32 -> bytes (already in the least significant bytes)
-            // (this is what abi.encode would produce)
+            // assume the address was encoded by converting address -> uint -> bytes32 -> bytes
+            // (already in the least significant bytes, no shifting needed; this is what abi.encode would produce)
             address stakeBeneficiary;
             assembly { stakeBeneficiary := calldataload(data.offset) } // solhint-disable-line no-inline-assembly
             _stake(stakeBeneficiary, amount);
@@ -202,9 +175,9 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
     function _addSponsorship(address sponsorAddress, uint amountWei) internal {
         // TODO: sweep also unaccounted tokens into unallocated funds?
         moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onSponsor.selector, sponsorAddress, amountWei), "error_sponsorFailed");
-        globalData().unallocatedFunds += amountWei;
+        unallocatedWei += amountWei;
         emit SponsorshipReceived(sponsorAddress, amountWei);
-        emit BountyUpdate(globalData().totalStakedWei, globalData().unallocatedFunds, solventUntil(), globalData().brokerCount, isRunning());
+        emit BountyUpdate(totalStakedWei, unallocatedWei, solventUntil(), uint32(brokerCount), isRunning());
     }
 
     /**
@@ -218,28 +191,27 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
 
     function _stake(address broker, uint amountWei) internal {
         // console.log("join/stake at ", block.timestamp, broker, amountWei);
-        GlobalStorage storage s = globalData();
-        require(amountWei >= s.minimumStakeWei, "error_minimumStake");
-        if (s.stakedWei[broker] == 0) {
+        require(amountWei >= minimumStakeWei, "error_minimumStake");
+        if (stakedWei[broker] == 0) {
            // console.log("Broker joins and stakes", broker, amountWei);
             for (uint i = 0; i < joinPolicies.length; i++) {
                 IJoinPolicy joinPolicy = joinPolicies[i];
                 moduleCall(address(joinPolicy), abi.encodeWithSelector(joinPolicy.onJoin.selector, broker, amountWei), "error_joinPolicyOnJoin");
             }
-            s.stakedWei[broker] += amountWei;
-            s.brokerCount += 1;
-            s.totalStakedWei += amountWei;
-            s.joinTimeOfBroker[broker] = block.timestamp; // solhint-disable-line not-rely-on-time
+            stakedWei[broker] += amountWei;
+            brokerCount += 1;
+            totalStakedWei += amountWei;
+            joinTimeOfBroker[broker] = block.timestamp; // solhint-disable-line not-rely-on-time
             moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onJoin.selector, broker), "error_allocationPolicyOnJoin");
             emit BrokerJoined(broker);
         } else {
            // console.log("Broker already joined, increasing stake", broker, amountWei);
-            s.stakedWei[broker] += amountWei;
-            s.totalStakedWei += amountWei;
+            stakedWei[broker] += amountWei;
+            totalStakedWei += amountWei;
             moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onStakeChange.selector, broker, int(amountWei)), "error_stakeIncreaseFailed");
         }
-        emit StakeUpdate(broker, s.stakedWei[broker], getAllocation(broker));
-        emit BountyUpdate(s.totalStakedWei, s.unallocatedFunds, solventUntil(), s.brokerCount, isRunning());
+        emit StakeUpdate(broker, stakedWei[broker], getEarnings(broker));
+        emit BountyUpdate(totalStakedWei, unallocatedWei, solventUntil(), uint32(brokerCount), isRunning());
     }
 
     /**
@@ -250,7 +222,7 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
         address broker = _msgSender();
         uint penaltyWei = getLeavePenalty(broker);
         require(penaltyWei == 0, "error_leavePenalty");
-        require(globalData().committedStakeWei[broker] == 0, "error_activeFlag");
+        require(committedStakeWei[broker] == 0, "error_activeFlag");
         _removeBroker(broker);
     }
 
@@ -268,21 +240,20 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
     /** Reduce your stake in the bounty without leaving */
     function reduceStakeTo(uint targetStakeWei) external {
         address broker = _msgSender();
-        GlobalStorage storage s = globalData();
-        require(targetStakeWei < s.stakedWei[broker], "error_cannotIncreaseStake");
+        require(targetStakeWei < stakedWei[broker], "error_cannotIncreaseStake");
         require(targetStakeWei >= minimumStakeOf(broker), "error_minimumStake");
 
-        uint cashoutWei = s.stakedWei[broker] - targetStakeWei;
+        uint cashoutWei = stakedWei[broker] - targetStakeWei;
         _reduceStakeBy(broker, cashoutWei);
         token.transfer(broker, cashoutWei);
 
-        emit StakeUpdate(broker, s.stakedWei[broker], getAllocation(broker));
-        emit BountyUpdate(s.totalStakedWei, s.unallocatedFunds, solventUntil(), s.brokerCount, isRunning());
+        emit StakeUpdate(broker, stakedWei[broker], getEarnings(broker));
+        emit BountyUpdate(totalStakedWei, unallocatedWei, solventUntil(), uint32(brokerCount), isRunning());
     }
 
     /**
-     * Slashing moves tokens from a broker's stake to "free funds" (that are not in unallocatedFunds!)
-     * @dev The caller MUST ensure those tokens are added to some other account, e.g. unallocatedFunds, via _addSponsorship
+     * Slashing moves tokens from a broker's stake to "free funds" (that are not in unallocatedWei!)
+     * @dev The caller MUST ensure those tokens are added to some other account, e.g. unallocatedWei, via _addSponsorship
      * @dev do not slash more than the whole stake!
      **/
     function _slash(address broker, uint amountWei) internal {
@@ -291,12 +262,12 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
         if (broker.code.length > 0) {
             try IBroker(broker).onSlash() {} catch {}
         }
-        emit StakeUpdate(broker, globalData().stakedWei[broker], getAllocation(broker));
+        emit StakeUpdate(broker, stakedWei[broker], getEarnings(broker));
     }
 
     /**
      * Kicking does what slashing does, plus removes the broker
-     * @dev The caller MUST ensure those tokens are added to some other account, e.g. unallocatedFunds, via _addSponsorship
+     * @dev The caller MUST ensure those tokens are added to some other account, e.g. unallocatedWei, via _addSponsorship
      * @dev do not slash more than the whole stake!
      */
     function _kick(address broker, uint slashingWei) internal {
@@ -309,15 +280,14 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
     }
 
     /**
-     * Moves tokens from a broker's stake to "free funds" (that are not in unallocatedFunds!)
+     * Moves tokens from a broker's stake to "free funds" (that are not in unallocatedWei!)
      * Does not actually send out tokens!
-     * @dev The caller MUST ensure those tokens are added to some other account, e.g. unallocatedFunds, via _addSponsorship
+     * @dev The caller MUST ensure those tokens are added to some other account, e.g. unallocatedWei, via _addSponsorship
      **/
     function _reduceStakeBy(address broker, uint amountWei) private {
-        GlobalStorage storage s = globalData();
-        assert(amountWei <= s.stakedWei[broker]); // should never happen! _slashing must be designed to not slash more than the whole stake
-        s.stakedWei[broker] -= amountWei;
-        s.totalStakedWei -= amountWei;
+        assert(amountWei <= stakedWei[broker]); // should never happen! _slashing must be designed to not slash more than the whole stake
+        stakedWei[broker] -= amountWei;
+        totalStakedWei -= amountWei;
         moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onStakeChange.selector, broker, -int(amountWei)), "error_stakeChangeHandlerFailed");
     }
 
@@ -327,29 +297,28 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
      * If broker had any committed stake, it is forfeited and accounted as committedFundsWei, under control of e.g. the VoteKickPolicy.
      */
     function _removeBroker(address broker) internal {
-        GlobalStorage storage s = globalData();
-        require(s.stakedWei[broker] > 0, "error_brokerNotStaked");
+        require(stakedWei[broker] > 0, "error_brokerNotStaked");
         // console.log("_removeBroker", broker);
 
-        if (globalData().committedStakeWei[broker] > 0) {
-            _slash(broker, globalData().committedStakeWei[broker]);
-            globalData().committedFundsWei += globalData().committedStakeWei[broker];
-            globalData().committedStakeWei[broker] = 0;
+        if (committedStakeWei[broker] > 0) {
+            _slash(broker, committedStakeWei[broker]);
+            committedFundsWei += committedStakeWei[broker];
+            committedStakeWei[broker] = 0;
         }
 
         // send out both allocations and stake
         _withdraw(broker);
-        uint paidOutStakeWei = s.stakedWei[broker];
+        uint paidOutStakeWei = stakedWei[broker];
         require(token.transferAndCall(broker, paidOutStakeWei, "stake"), "error_transfer");
 
-        s.brokerCount -= 1;
-        s.totalStakedWei -= paidOutStakeWei;
-        delete s.stakedWei[broker];
-        delete s.joinTimeOfBroker[broker];
+        brokerCount -= 1;
+        totalStakedWei -= paidOutStakeWei;
+        delete stakedWei[broker];
+        delete joinTimeOfBroker[broker];
 
         moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onLeave.selector, broker), "error_leaveHandlerFailed");
         emit StakeUpdate(broker, 0, 0); // stake and allocation must be zero when the broker is gone
-        emit BountyUpdate(s.totalStakedWei, s.unallocatedFunds, solventUntil(), s.brokerCount, isRunning());
+        emit BountyUpdate(totalStakedWei, unallocatedWei, solventUntil(), uint32(brokerCount), isRunning());
         emit BrokerLeft(broker, paidOutStakeWei);
     }
 
@@ -357,13 +326,12 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
     /** Get earnings out, leave stake in */
     function withdraw() external returns (uint payoutWei) {
         address broker = _msgSender();
-        uint stakedWei = globalData().stakedWei[broker];
-        require(stakedWei > 0, "error_brokerNotStaked");
+        require(stakedWei[broker] > 0, "error_brokerNotStaked");
 
         payoutWei = _withdraw(broker);
         if (payoutWei > 0) {
-            emit StakeUpdate(broker, globalData().stakedWei[broker], 0); // earnings will be zero after withdraw (see test)
-            emit BountyUpdate(globalData().totalStakedWei, globalData().unallocatedFunds, solventUntil(), globalData().brokerCount, isRunning());
+            emit StakeUpdate(broker, stakedWei[broker], 0); // earnings will be zero after withdraw (see test)
+            emit BountyUpdate(totalStakedWei, unallocatedWei, solventUntil(), uint32(brokerCount), isRunning());
         }
     }
 
@@ -478,8 +446,8 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
         return moduleGet(abi.encodeWithSelector(allocationPolicy.getInsolvencyTimestamp.selector, address(allocationPolicy)), "error_getInsolvencyTimestampFailed");
     }
 
-    function getAllocation(address broker) public view returns(uint256 allocation) {
-        return moduleGet(abi.encodeWithSelector(allocationPolicy.calculateAllocation.selector, broker, address(allocationPolicy)), "error_getAllocationFailed");
+    function getEarnings(address broker) public view returns(uint256 allocation) {
+        return moduleGet(abi.encodeWithSelector(allocationPolicy.getEarningsWei.selector, broker, address(allocationPolicy)), "error_getEarningsFailed");
     }
 
     function getLeavePenalty(address broker) public view returns(uint256 leavePenalty) {

--- a/packages/network-contracts/contracts/BrokerEconomics/BountyFactory.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BountyFactory.sol
@@ -10,6 +10,10 @@ import "./Bounty.sol";
 import "./IERC677.sol";
 import "./StreamrConfig.sol";
 
+/**
+ * BountyFactory creates Bounties that respect Streamr Network rules and StreamrConfig.
+ * Only Bounties from this BountyFactory can be used in Streamr Network, and staked into by BrokerPools.
+ */
 contract BountyFactory is Initializable, UUPSUpgradeable, ERC2771ContextUpgradeable, AccessControlUpgradeable {
 
     StreamrConfig public streamrConfig;
@@ -24,12 +28,12 @@ contract BountyFactory is Initializable, UUPSUpgradeable, ERC2771ContextUpgradea
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() ERC2771ContextUpgradeable(address(0x0)) {}
 
-    function initialize(address templateAddress, address _tokenAddress, address constants) public initializer {
+    function initialize(address templateAddress, address dataTokenAddress, address streamrConfigAddress) public initializer {
         __AccessControl_init();
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        tokenAddress = _tokenAddress;
+        tokenAddress = dataTokenAddress;
         bountyContractTemplate = templateAddress;
-        streamrConfig = StreamrConfig(constants);
+        streamrConfig = StreamrConfig(streamrConfigAddress);
     }
 
     function _authorizeUpgrade(address) internal override {}

--- a/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/BrokerPoolOnlyJoinPolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/BrokerPoolOnlyJoinPolicy.sol
@@ -16,6 +16,6 @@ contract BrokerPoolOnlyJoinPolicy is IJoinPolicy, Bounty {
     // only BrokerPool contracts that were deployed using our own BrokerPoolFactory are allowed to join
     // solc-ignore-next-line func-mutability
     function onJoin(address broker, uint256) external {
-        require(IFactory(globalData().streamrConfig.brokerPoolFactory()).deploymentTimestamp(broker) > 0, "error_onlyBrokerPools");
+        require(IFactory(streamrConfig.brokerPoolFactory()).deploymentTimestamp(broker) > 0, "error_onlyBrokerPools");
     }
 }

--- a/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/DefaultLeavePolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/DefaultLeavePolicy.sol
@@ -14,13 +14,13 @@ contract DefaultLeavePolicy is ILeavePolicy, Bounty {
      * During penaltyPeriod, leaving is only okay if bounty is not running
      */
     function getLeavePenaltyWei(address broker) public override view returns (uint leavePenaltyWei) {
-        uint joinTimestamp = globalData().joinTimeOfBroker[broker];
+        uint joinTimestamp = joinTimeOfBroker[broker];
         if (block.timestamp >= joinTimestamp + penaltyPeriodSeconds) { // solhint-disable-line not-rely-on-time
             // console.log("Penalty period over, get stake back");
             return 0;
         }
 
-        uint stake = globalData().stakedWei[broker];
+        uint stake = stakedWei[broker];
         // console.log("getLeavePenaltyWei, stake =", stake, isRunning() ? "[running]" : "[NOT running]", isFunded() ? "[funded]" : "[NOT funded]");
         if (isRunning() && isFunded()) {
             // console.log("Leaving a running bounty too early, lose 10% of stake");
@@ -31,7 +31,7 @@ contract DefaultLeavePolicy is ILeavePolicy, Bounty {
     }
 
     function setParam(uint256 penaltyPeriod) external {
-        require (penaltyPeriod <= globalData().streamrConfig.maxPenaltyPeriodSeconds(), "error_penaltyPeriodTooLong");
+        require (penaltyPeriod <= streamrConfig.maxPenaltyPeriodSeconds(), "error_penaltyPeriodTooLong");
         penaltyPeriodSeconds = penaltyPeriod;
     }
 }

--- a/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/IAllocationPolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/IAllocationPolicy.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 
 interface IAllocationPolicy {
     function setParam(uint param) external;
-    function calculateAllocation(address broker) external view returns (uint allocation);
+    function getEarningsWei(address broker) external view returns (uint earningsWei);
     function getInsolvencyTimestamp() external view returns (uint insolvencyTimestamp);
     function onJoin(address broker) external;
     function onLeave(address broker) external;

--- a/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/MaxAmountBrokersJoinPolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/MaxAmountBrokersJoinPolicy.sol
@@ -24,6 +24,6 @@ contract MaxAmountBrokersJoinPolicy is IJoinPolicy, Bounty {
     /** Check if there's room for one more */
     // solc-ignore-next-line func-mutability
     function onJoin(address, uint256) external {
-        require(globalData().brokerCount < localData().maxBrokers, "error_tooManyBrokers");
+        require(brokerCount < localData().maxBrokers, "error_tooManyBrokers");
     }
 }

--- a/packages/network-contracts/contracts/BrokerEconomics/BrokerPool.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BrokerPool.sol
@@ -44,23 +44,29 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
     bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     bytes32 public constant TRUSTED_FORWARDER_ROLE = keccak256("TRUSTED_FORWARDER_ROLE");
 
-    uint public minimumDelegationWei;
+    IPoolJoinPolicy public joinPolicy;
+    IPoolYieldPolicy public yieldPolicy;
+    IPoolExitPolicy public exitPolicy;
+
+    StreamrConfig streamrConfig;
 
     /**
      * The time the broker is given for paying out the exit queue.
      * If the front of the queue is older than maxQueueSeconds, anyone can call forceUnstake to pay out the queue.
      */
     uint public maxQueueSeconds;
-    IPoolJoinPolicy public joinPolicy;
-    IPoolYieldPolicy public yieldPolicy;
-    IPoolExitPolicy public exitPolicy;
 
+    uint public minimumDelegationWei;
     address public broker;
-    struct GlobalStorage {
-        IERC677 token;
-        uint totalValueInBountiesWei; // DATA value of all stake + earnings in bounties - broker's share of those earnings
-        StreamrConfig streamrConfig;
-    }
+    IERC677 token;
+
+    // Pool value = DATA value of all stake + earnings in bounties - broker's share of those earnings
+    // It can be queried and calculated in three ways:
+    // 1. accurate but expensive: calculatePoolValueInData() (loops over bounties)
+    // 2. approximate but always available: totalValueInBountiesWei (updated in staking/unstaking and updateApproximatePoolvalueOfBounty/Bounties)
+    // 3. val = totalValueInBountiesWei + free funds
+    uint totalValueInBountiesWei;
+    mapping(Bounty => uint) public approxPoolValueOfBounty; // in Data wei
 
     Bounty[] public bounties;
     mapping(Bounty => uint) public indexOfBounties; // bounties array index PLUS ONE! use 0 as "is it already in the array?" check
@@ -78,12 +84,6 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
     address[] public nodes;
     mapping(address => uint) public nodeIndex; // index in nodes array PLUS ONE
 
-    // triple bookkeeping
-    // 1. real actual poolvalue = local free funds + stake in bounties + allocation in bounties; loops over bounties
-    // 2. val = Sum over local mapping approxPoolValueOfBounty + free funds
-    // 3. val = approxPoolValue in globalstorage
-    mapping(Bounty => uint) public approxPoolValueOfBounty; // in Data wei
-
     modifier onlyBroker() {
         require(_msgSender() == broker, "error_onlyBroker");
         _;
@@ -99,7 +99,7 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
 
     function initialize(
         address tokenAddress,
-        address streamrConfig,
+        address streamrConfigAddress,
         address brokerAddress,
         string calldata poolName,
         uint initialMinimumDelegationWei
@@ -107,14 +107,14 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
         __AccessControl_init();
         _setupRole(ADMIN_ROLE, brokerAddress);
         _setRoleAdmin(TRUSTED_FORWARDER_ROLE, ADMIN_ROLE); // admin can set the GSN trusted forwarder
-        globalData().token = IERC677(tokenAddress);
+        token = IERC677(tokenAddress);
         broker = brokerAddress;
-        globalData().streamrConfig = StreamrConfig(streamrConfig);
+        streamrConfig = StreamrConfig(streamrConfigAddress);
         minimumDelegationWei = initialMinimumDelegationWei;
         ERC20Upgradeable.__ERC20_init(poolName, poolName);
 
         // fixed queue emptying requirement is simplest for now. This ensures a diligent broker can always pay out the exit queue without getting leavePenalties
-        maxQueueSeconds = globalData().streamrConfig.maxPenaltyPeriodSeconds();
+        maxQueueSeconds = streamrConfig.maxPenaltyPeriodSeconds();
 
         // DEFAULT_ADMIN_ROLE is needed (by factory) for setting modules
         _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
@@ -128,14 +128,9 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
         return super._msgData();
     }
 
-    function globalData() internal pure returns(GlobalStorage storage data) {
-        bytes32 storagePosition = keccak256("brokerpool.storage.GlobalStorage");
-        assembly { data.slot := storagePosition } // solhint-disable-line no-inline-assembly
-    }
-
     /** Pool value (DATA) = staked in bounties + free funds */
     function getApproximatePoolValue() public view returns (uint) {
-        return globalData().totalValueInBountiesWei + globalData().token.balanceOf(address(this));
+        return totalValueInBountiesWei + token.balanceOf(address(this));
     }
 
     function getMyBalanceInData() public view returns (uint256 amountDataWei) {
@@ -166,23 +161,23 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
     function onTokenTransfer(address sender, uint amount, bytes calldata data) external {
         // console.log("## onTokenTransfer from", sender);
         // console.log("onTokenTransfer amount", amount);
-        require(_msgSender() == address(globalData().token), "error_onlyDATAToken");
+        require(_msgSender() == address(token), "error_onlyDATAToken");
 
         if (data.length == 20) {
-            // shift 20 bytes (= 160 bits) to end of uint256 to make it an address => shift by 256 - 160 = 96
+            // shift the 20 address bytes (= 160 bits) to end of uint256 to populate an address variable => shift by 256 - 160 = 96
             // (this is what abi.encodePacked would produce)
             address delegator;
             assembly { delegator := shr(96, calldataload(data.offset)) } // solhint-disable-line no-inline-assembly
             _delegate(delegator, amount);
         } else if (data.length == 32) {
-            // assume the address was encoded by converting address -> uint -> bytes32 -> bytes (already in the least significant bytes)
-            // (this is what abi.encode would produce)
+            // assume the address was encoded by converting address -> uint -> bytes32 -> bytes
+            // (already in the least significant bytes, no shifting needed; this is what abi.encode would produce)
             address delegator;
             assembly { delegator := calldataload(data.offset) } // solhint-disable-line no-inline-assembly
             _delegate(delegator, amount);
         } else {
             // check if sender is a bounty: unstaking/withdrawing from bounties will call this method
-            // ignore returned tokens, handle them in unstake() instead
+            // ignore returned tokens, handle them in unstake()/withdraw() instead
             Bounty bounty = Bounty(sender);
             if (indexOfBounties[bounty] > 0) {
                 return;
@@ -195,7 +190,7 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
     /** Delegate by first calling DATA.approve(brokerPool.address, amountWei) then this function */
     function delegate(uint amountWei) public payable {
         // console.log("## delegate");
-        globalData().token.transferFrom(_msgSender(), address(this), amountWei);
+        token.transferFrom(_msgSender(), address(this), amountWei);
         _delegate(_msgSender(), amountWei);
     }
 
@@ -235,15 +230,15 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
      * This means the broker must clear the queue as part of normal operation before they can change staking allocations.
      **/
     function stake(Bounty bounty, uint amountWei) external onlyBroker {
-        require(BountyFactory(globalData().streamrConfig.bountyFactory()).deploymentTimestamp(address(bounty)) > 0, "error_badBounty");
+        require(BountyFactory(streamrConfig.bountyFactory()).deploymentTimestamp(address(bounty)) > 0, "error_badBounty");
         require(queueIsEmpty(), "error_firstEmptyQueueThenStake");
-        globalData().token.approve(address(bounty), amountWei);
+        token.approve(address(bounty), amountWei);
         if (indexOfBounties[bounty] == 0) {
             bounty.stake(address(this), amountWei); // may fail if amountWei < minimumStake
             bounties.push(bounty);
             indexOfBounties[bounty] = bounties.length; // real array index + 1
             approxPoolValueOfBounty[bounty] += amountWei;
-            globalData().totalValueInBountiesWei += amountWei;
+            totalValueInBountiesWei += amountWei;
         }
         emit Staked(bounty, amountWei);
     }
@@ -268,14 +263,14 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
         updateApproximatePoolvalueOfBounty(bounty);
     }
 
-    function withdrawWinningsFromBounty(Bounty bounty) external onlyBroker {
+    function withdrawEarningsFromBounty(Bounty bounty) external onlyBroker {
         updateApproximatePoolvalueOfBounty(bounty); // TODO: why is update needed before withdraw?
-        withdrawWinningsFromBountyWithoutQueue(bounty);
+        withdrawEarningsFromBountyWithoutQueue(bounty);
         payOutQueueWithFreeFunds(0);
     }
 
     /** In case the queue is very long (e.g. due to spamming), give the broker an option to free funds from Bounties to pay out the queue in parts */
-    function withdrawWinningsFromBountyWithoutQueue(Bounty bounty) public onlyBroker {
+    function withdrawEarningsFromBountyWithoutQueue(Bounty bounty) public onlyBroker {
         uint payoutWei = bounty.withdraw();
         moduleCall(address(yieldPolicy), abi.encodeWithSelector(yieldPolicy.deductBrokersShare.selector, payoutWei), "error_deductBrokersShareFailed");
         updateApproximatePoolvalueOfBounty(bounty);
@@ -293,7 +288,7 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
     /** In case the queue is very long (e.g. due to spamming), give the broker an option to free funds from Bounties to pay out the queue in parts */
     function unstakeWithoutQueue(Bounty bounty) public onlyBroker {
         uint amountStakedBeforeWei = bounty.getMyStake();
-        uint balanceBeforeWei = globalData().token.balanceOf(address(this));
+        uint balanceBeforeWei = token.balanceOf(address(this));
         bounty.unstake();
         _postUnstake(bounty, amountStakedBeforeWei, balanceBeforeWei);
     }
@@ -313,18 +308,18 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
         }
 
         uint amountStakedBeforeWei = bounty.getMyStake();
-        uint balanceBeforeWei = globalData().token.balanceOf(address(this));
+        uint balanceBeforeWei = token.balanceOf(address(this));
         bounty.forceUnstake();
         _postUnstake(bounty, amountStakedBeforeWei, balanceBeforeWei);
         payOutQueueWithFreeFunds(maxQueuePayoutIterations);
     }
 
     function _postUnstake(Bounty bounty, uint amountStakedBeforeWei, uint balanceBeforeWei) private {
-        uint receivedWei = globalData().token.balanceOf(address(this)) - balanceBeforeWei;
-        globalData().totalValueInBountiesWei -= approxPoolValueOfBounty[bounty];
+        uint receivedWei = token.balanceOf(address(this)) - balanceBeforeWei;
+        totalValueInBountiesWei -= approxPoolValueOfBounty[bounty];
         // console.log("bounties approx pool value", approxPoolValueOfBounty[bounty]);
         // console.log("unstake receivedWei", receivedWei);
-        // console.log("unstake new approxPoolValue", globalData().approxPoolValue);
+        // console.log("unstake new approxPoolValue", approxPoolValue);
         approxPoolValueOfBounty[bounty] = 0;
 
         // TODO: here earnings are mixed together with stake. Maybe that's ok though.
@@ -444,9 +439,10 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
     }
 
     /**
-     * Answers 'how many queue positions must be paid out before I get (all) my queued tokens?'
+     * Get the position of the LAST undelegation request in the queue for the given delegator.
+     * Answers the question 'how many queue positions must (still) be paid out before I get (all) my queued tokens?'
      *   for the purposes of "self-service undelegation" (forceUnstake or payOutQueueWithFreeFunds)
-     * If you're not in the queue, returns just the length of the queue + 1 (i.e. the position you'd get if you undelegate now)
+     * If delegator is not in the queue, returns just the length of the queue + 1 (i.e. the position they'd get if they undelegate now)
      */
     function queuePositionOf(address delegator) external view returns (uint) {
         for (uint i = queueLastIndex - 1; i >= queueCurrentIndex; i--) {
@@ -476,7 +472,7 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
      * @return payoutComplete true if the queue is empty afterwards or funds have run out
      */
     function payOutFirstInQueue() public returns (bool payoutComplete) {
-        uint balanceDataWei = globalData().token.balanceOf(address(this));
+        uint balanceDataWei = token.balanceOf(address(this));
         if (balanceDataWei == 0 || queueIsEmpty()) {
             return true;
         }
@@ -503,7 +499,7 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
             queueCurrentIndex++;
             totalQueuedPerDelegatorWei[user] -= amountPoolTokens;
             _burn(user, amountPoolTokens);
-            globalData().token.transfer(user, amountDataWei);
+            token.transfer(user, amountDataWei);
             emit Undelegated(user, amountDataWei);
             return queueIsEmpty();
         } else {
@@ -517,7 +513,7 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
             uint256 poolTokensLeftInQueue = oldEntry.amountPoolTokenWei - partialAmountPoolTokens;
             undelegationQueue[queueCurrentIndex] = UndelegationQueueEntry(oldEntry.user, poolTokensLeftInQueue, oldEntry.timestamp);
             _burn(user, partialAmountPoolTokens);
-            globalData().token.transfer(user, balanceDataWei);
+            token.transfer(user, balanceDataWei);
             emit Undelegated(user, balanceDataWei);
             emit QueueUpdated(user, poolTokensLeftInQueue);
             return false;
@@ -545,7 +541,7 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
     }
 
     function onReviewRequest(address targetBroker) external {
-        require(BountyFactory(globalData().streamrConfig.bountyFactory()).deploymentTimestamp(msg.sender) > 0, "error_onlyBounty");
+        require(BountyFactory(streamrConfig.bountyFactory()).deploymentTimestamp(msg.sender) > 0, "error_onlyBounty");
         Bounty bounty = Bounty(msg.sender);
         emit ReviewRequest(bounty, targetBroker);
     }
@@ -640,15 +636,15 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
         uint actual = getPoolValueFromBounty(bounty);
         uint approx = approxPoolValueOfBounty[bounty];
         approxPoolValueOfBounty[bounty] = actual;
-        globalData().totalValueInBountiesWei = globalData().totalValueInBountiesWei + actual - approx;
+        totalValueInBountiesWei = totalValueInBountiesWei + actual - approx;
     }
 
     /**
-     * The accurate "accounting value" of a bounty = stake + allocation - broker's share of the allocation
+     * The accurate "accounting value" of a bounty = stake + earnings - broker's share of the earnings
      * This value will be used to calculate the total pool value, and therefore also the pool token exchange rate
      **/
     function getPoolValueFromBounty(Bounty bounty) public view returns (uint256 poolValue) {
-        uint alloc = bounty.getAllocation(address(this));
+        uint alloc = bounty.getEarnings(address(this));
         uint share = moduleGet(abi.encodeWithSelector(yieldPolicy.calculateBrokersShare.selector, alloc, address(yieldPolicy)), "error_calculateBrokersShare_Failed");
         poolValue = bounty.getMyStake() + alloc - share;
     }
@@ -660,15 +656,15 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
      * @dev Don't call from other smart contracts in a transaction, could be expensive!
      **/
     function getApproximatePoolValuesPerBounty() external view returns (
-        address[] memory bountyAdresses,
+        address[] memory bountyAddresses,
         uint[] memory approxValues,
         uint[] memory realValues
     ) {
-        bountyAdresses = new address[](bounties.length);
+        bountyAddresses = new address[](bounties.length);
         approxValues = new uint[](bounties.length);
         realValues = new uint[](bounties.length);
         for (uint i = 0; i < bounties.length; i++) {
-            bountyAdresses[i] = address(bounties[i]);
+            bountyAddresses[i] = address(bounties[i]);
             approxValues[i] = approxPoolValueOfBounty[bounties[i]];
             realValues[i] = getPoolValueFromBounty(bounties[i]);
         }
@@ -681,7 +677,7 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
      * TODO: is this function needed? getApproximatePoolValuesPerBounty gives same info, and more
      */
     function calculatePoolValueInData() external view returns (uint256 poolValue) {
-        poolValue = globalData().token.balanceOf(address(this));
+        poolValue = token.balanceOf(address(this));
         for (uint i = 0; i < bounties.length; i++) {
             poolValue += getPoolValueFromBounty(bounties[i]);
         }
@@ -704,13 +700,13 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
 
             approxPoolValueOfBounty[bounty] = actual;
         }
-        globalData().totalValueInBountiesWei = globalData().totalValueInBountiesWei + sumActual - sumApprox;
+        totalValueInBountiesWei = totalValueInBountiesWei + sumActual - sumApprox;
 
         // if total difference is more than allowed, then slash the broker a bit: move some of their pool tokens to reward the caller
         // TODO: this could move pool tokens to someone who isn't delegated into the pool! TODO: Add them if they're not in the pool?
-        uint allowedDifference = getApproximatePoolValue() * globalData().streamrConfig.poolValueDriftLimitFraction() / 1 ether;
+        uint allowedDifference = getApproximatePoolValue() * streamrConfig.poolValueDriftLimitFraction() / 1 ether;
         if (sumActual > sumApprox + allowedDifference) {
-            _transfer(broker, _msgSender(), balanceOf(broker) * globalData().streamrConfig.poolValueDriftPenaltyFraction() / 1 ether);
+            _transfer(broker, _msgSender(), balanceOf(broker) * streamrConfig.poolValueDriftPenaltyFraction() / 1 ether);
         }
     }
 }

--- a/packages/network-contracts/contracts/BrokerEconomics/BrokerPoolFactory.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BrokerPoolFactory.sol
@@ -11,12 +11,16 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "./BrokerPool.sol";
 import "./IERC677.sol";
 
+/**
+ * BrokerPoolFactory creates "smart contract interfaces" for brokers to the Streamr Network.
+ * Only BrokerPools from this BrokerPoolFactory can stake to Streamr Network Bounties.
+ */
 contract BrokerPoolFactory is Initializable, UUPSUpgradeable, ERC2771ContextUpgradeable, AccessControlUpgradeable {
 
     bytes32 public constant TRUSTED_FORWARDER_ROLE = keccak256("TRUSTED_FORWARDER_ROLE");
 
     address public brokerPoolTemplate;
-    address public streamrConfig;
+    address public configAddress;
     address public tokenAddress;
     mapping(address => bool) public trustedPolicies;
     mapping(address => uint) public deploymentTimestamp; // zero for contracts not deployed by this factory
@@ -32,11 +36,11 @@ contract BrokerPoolFactory is Initializable, UUPSUpgradeable, ERC2771ContextUpgr
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() ERC2771ContextUpgradeable(address(0x0)) {}
 
-    function initialize(address templateAddress, address _tokenAddress, address constants) public initializer {
+    function initialize(address templateAddress, address dataTokenAddress, address streamrConfigAddress) public initializer {
         __AccessControl_init();
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
-        streamrConfig = constants;
-        tokenAddress = _tokenAddress;
+        configAddress = streamrConfigAddress;
+        tokenAddress = dataTokenAddress;
         brokerPoolTemplate = templateAddress;
     }
 
@@ -128,7 +132,7 @@ contract BrokerPoolFactory is Initializable, UUPSUpgradeable, ERC2771ContextUpgr
         BrokerPool pool = BrokerPool(poolAddress);
         pool.initialize(
             tokenAddress,
-            streamrConfig,
+            configAddress,
             poolOwner,
             poolName,
             initialMinimumDelegationWei

--- a/packages/network-contracts/contracts/BrokerEconomics/BrokerPoolPolicies/DefaultPoolYieldPolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BrokerPoolPolicies/DefaultPoolYieldPolicy.sol
@@ -50,7 +50,7 @@ contract DefaultPoolYieldPolicy is IPoolYieldPolicy, BrokerPool {
         }
         // consolelog("DefaultPoolYieldPolicy.pooltokenToData amount to convert", poolTokenWei);
         // consolelog("DefaultPoolYieldPolicy.pooltokenToData substract", substractFromPoolvalue);
-        // consolelog("DefaultPoolYieldPolicy.pooltokenToData data balance of this", globalData().token.balanceOf(address(this)));
+        // consolelog("DefaultPoolYieldPolicy.pooltokenToData data balance of this", token.balanceOf(address(this)));
         // consolelog("DefaultPoolYieldPolicy.pooltokenToData this totlasupply", this.totalSupply());
         // uint poolValueData = this.calculatePoolValueInData(substractFromPoolvalue);
         uint poolValueData = getApproximatePoolValue() - substractFromPoolvalue;
@@ -69,7 +69,7 @@ contract DefaultPoolYieldPolicy is IPoolYieldPolicy, BrokerPool {
         assert(substractFromPoolvalue < poolValue);
         // consolelog("DefaultPoolYieldPolicy.dataToPooltoken amount to convert", dataWei);
         // consolelog("DefaultPoolYieldPolicy.dataToPooltoken substract", substractFromPoolvalue);
-        // consolelog("DefaultPoolYieldPolicy.dataToPooltoken data balance of this", globalData().token.balanceOf(address(this)));
+        // consolelog("DefaultPoolYieldPolicy.dataToPooltoken data balance of this", token.balanceOf(address(this)));
         // uint poolValueData = this.calculatePoolValueInData(substractFromPoolvalue);
         uint poolValueData = poolValue - substractFromPoolvalue;
         // consolelog("DefaultPoolYieldPolicy.dataToPooltoken data this totlasupply", this.totalSupply());
@@ -100,8 +100,8 @@ contract DefaultPoolYieldPolicy is IPoolYieldPolicy, BrokerPool {
 
             uint256 missingPoolToken = brokerStakeGoal - balanceOf(broker);
             // consolelog("DefaultPoolYieldPolicy.deductBrokersShare.missingPoolToken", missingPoolToken);
-            // "2 *" comes from that the incoming winnings are already in the pool's balance;
-            //   and DOUBLE counted because update is done first and it adds winnings to total pool value
+            // "2 *" comes from that the incoming earnings are already in the pool's balance;
+            //   and DOUBLE counted because update is done first and it adds earnings to total pool value
             uint256 divertDataWei = pooltokenToData(missingPoolToken, 2 * dataWei - brokersShareDataWei); // brokers share is already deducted from poolvalue
             // consolelog("DefaultPoolYieldPolicy.deductBrokersShare.divertDataWei", divertDataWei);
             uint256 maxDivertableDataWei = brokersShareDataWei * localData().brokerShareMaxDivertPercent / 100;
@@ -115,7 +115,7 @@ contract DefaultPoolYieldPolicy is IPoolYieldPolicy, BrokerPool {
             _mint(broker, poolTokenToMint);
             // consolelog("DefaultPoolYieldPolicy.deductBrokersShare minted", poolTokenToMint);
         }
-        globalData().token.transfer(broker, brokersShareDataWei);
+        token.transfer(broker, brokersShareDataWei);
         // consolelog("DefaultPoolYieldPolicy.deductBrokersShare transferred data to broker", brokersShareDataWei);
         // return (brokersShareDataWei, poolTokenToMint);
 

--- a/packages/network-contracts/contracts/BrokerEconomics/StreamrConfig.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/StreamrConfig.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 /**
- * @title Chain-specific constants and addresses for the Streamr Network tokenomics (Bounty, BrokerPool)
+ * @title Chain-specific parameters and addresses for the Streamr Network tokenomics (Bounty, BrokerPool)
  */
 contract StreamrConfig is Initializable, UUPSUpgradeable, AccessControlUpgradeable {
 

--- a/packages/network-contracts/contracts/BrokerEconomics/testcontracts/TestAllocationPolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/testcontracts/TestAllocationPolicy.sol
@@ -85,7 +85,7 @@ contract TestAllocationPolicy is IAllocationPolicy, Bounty {
     function onSponsor(address, uint) external {
     }
 
-    function calculateAllocation(address) public view returns (uint allocation) {
+    function getEarningsWei(address) public view returns (uint earningsWei) {
     }
 
     function calculatePenaltyOnStake(address) external view returns (uint256 stake) {

--- a/packages/network-contracts/scripts/tatum/1_deployBountyFactory.ts
+++ b/packages/network-contracts/scripts/tatum/1_deployBountyFactory.ts
@@ -24,9 +24,9 @@ const localConfig: any = {}
 
 async function deployBountyFactory() {
     log((await ethers.getSigners())[0].address)
-    const streamrConstantsFactory = await ethers.getContractFactory("StreamrConfig", { signer: adminWallet })
-    const streamrConstantsFactoryTx = await upgrades.deployProxy(streamrConstantsFactory, [], { kind: "uups" })
-    const streamrConfig = await streamrConstantsFactoryTx.deployed() as StreamrConfig
+    const streamrConfigFactory = await ethers.getContractFactory("StreamrConfig", { signer: adminWallet })
+    const streamrConfigFactoryTx = await upgrades.deployProxy(streamrConfigFactory, [], { kind: "uups" })
+    const streamrConfig = await streamrConfigFactoryTx.deployed() as StreamrConfig
     const hasroleEthSigner = await streamrConfig.hasRole(await streamrConfig.DEFAULT_ADMIN_ROLE(), adminWallet.address)
     log(`hasrole ${hasroleEthSigner}`)
     localConfig.streamrConfig = streamrConfig.address

--- a/packages/network-contracts/scripts/tatum/3_deployPoolContracts.ts
+++ b/packages/network-contracts/scripts/tatum/3_deployPoolContracts.ts
@@ -56,8 +56,8 @@ async function deployPoolFactory() {
     ])).wait()
     log("Added trusted policies")
 
-    const streamrConstantsFactory = await ethers.getContractFactory("StreamrConfig", { signer: deploymentOwner })
-    const streamrConfig = await streamrConstantsFactory.attach(localConfig.streamrConfig) as StreamrConfig
+    const streamrConfigFactory = await ethers.getContractFactory("StreamrConfig", { signer: deploymentOwner })
+    const streamrConfig = await streamrConfigFactory.attach(localConfig.streamrConfig) as StreamrConfig
     await (await streamrConfig.setBrokerPoolFactory(poolFactory.address)).wait()
     log("Set broker pool factory in StreamrConfig")
 }

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/Bounty.test.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/Bounty.test.ts
@@ -108,9 +108,9 @@ describe("Bounty", (): void => {
         await (await token.transferAndCall(bounty.address, parseEther("10"), broker.address)).wait()
 
         await advanceToTimestamp(start + 101, "Withdraw from bounty")
-        const allocationBeforeWithdraw = await bounty.getAllocation(broker.address)
+        const allocationBeforeWithdraw = await bounty.getEarnings(broker.address)
         await (await bounty.connect(broker).withdraw()).wait()
-        const allocationAfterWithdraw = await bounty.getAllocation(broker.address)
+        const allocationAfterWithdraw = await bounty.getEarnings(broker.address)
 
         expect(allocationBeforeWithdraw).to.equal(parseEther("100"))
         expect(allocationAfterWithdraw).to.equal(0)
@@ -126,10 +126,10 @@ describe("Bounty", (): void => {
         await (await token.transferAndCall(bounty.address, parseEther("10"), broker.address)).wait()
 
         await advanceToTimestamp(start + 101, "Withdraw from bounty") // queries will see start + 100 (off by one, NEXT tx will be start + 101)
-        const allocationBeforeUnstake = await bounty.getAllocation(broker.address)
+        const allocationBeforeUnstake = await bounty.getEarnings(broker.address)
         const stakeBeforeUnstake = await bounty.connect(broker).getMyStake()
         await (await bounty.connect(broker).unstake()).wait()
-        const allocationAfterUnstake = await bounty.getAllocation(broker.address)
+        const allocationAfterUnstake = await bounty.getEarnings(broker.address)
         const stakeAfterUnstake = await bounty.connect(broker).getMyStake()
 
         expect(allocationBeforeUnstake).to.equal(parseEther("100"))

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/AdminKickPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/AdminKickPolicy.test.ts
@@ -47,12 +47,12 @@ describe("AdminKickPolicy", (): void => {
         await (await token.connect(broker2).transferAndCall(bounty.address, parseEther("1000"), broker2.address)).wait()
 
         // event BrokerKicked(address indexed broker, uint slashedWei);
-        const brokerCountBeforeKick = await bounty.getBrokerCount()
+        const brokerCountBeforeKick = await bounty.brokerCount()
         await advanceToTimestamp(timeAtStart + 200, "broker 1 is kicked out")
         expect (await bounty.connect(admin).flag(await broker.getAddress()))
             .to.emit(bounty, "BrokerKicked")
             .withArgs(await broker.getAddress(), "0")
-        const brokerCountAfterKick = await bounty.getBrokerCount()
+        const brokerCountAfterKick = await bounty.brokerCount()
 
         await advanceToTimestamp(timeAtStart + 300, "broker 2 leaves and gets slashed")
         await (await bounty.connect(broker2).forceUnstake()).wait()
@@ -69,11 +69,11 @@ describe("AdminKickPolicy", (): void => {
         await (await token.mint(broker.address, parseEther("1000"))).wait()
         await (await token.connect(broker).transferAndCall(bounty.address, parseEther("1000"), await broker.getAddress())).wait()
 
-        const brokerCountBeforeReport = await bounty.getBrokerCount()
+        const brokerCountBeforeReport = await bounty.brokerCount()
         expect(bounty.connect(broker2).flag(await broker.getAddress()))
             .to.emit(bounty, "BrokerKicked")
             .withArgs(await broker.getAddress(), "0")
-        const brokerCountAfterReport = await bounty.getBrokerCount()
+        const brokerCountAfterReport = await bounty.brokerCount()
 
         expect(brokerCountBeforeReport.toString()).to.equal("1")
         expect(brokerCountAfterReport.toString()).to.equal("1")

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/VoteKickPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/VoteKickPolicy.test.ts
@@ -174,7 +174,7 @@ describe("VoteKickPolicy", (): void => {
             expect(await bounty.getFlag(target.address)).to.equal("0") // closed
 
             // target is not kicked
-            expect(await bounty.getStake(target.address)).to.not.equal("0")
+            expect(await bounty.stakedWei(target.address)).to.not.equal("0")
         })
 
         it("rewards the flagger", async function(): Promise<void> {
@@ -206,7 +206,7 @@ describe("VoteKickPolicy", (): void => {
             await (await voters[3].voteOnFlag(bounty.address, flagger.address, VOTE_KICK)).wait()
             await (await voters[4].voteOnFlag(bounty.address, flagger.address, VOTE_KICK)).wait()
 
-            expect(await bounty.getStake(flagger.address)).to.equal("0") // flagger is kicked
+            expect(await bounty.stakedWei(flagger.address)).to.equal("0") // flagger is kicked
 
             await advanceToTimestamp(start + VOTE_START + 50, `Voting to not kick ${addr(target)}`)
             await (await voters[0].voteOnFlag(bounty.address, target.address, VOTE_NO_KICK)).wait()
@@ -411,7 +411,7 @@ describe("VoteKickPolicy", (): void => {
             await (await voter.voteOnFlag(bounty.address, target.address, VOTE_NO_KICK)).wait()
             expect(await bounty.getFlag(target.address)).to.equal("0") // flag is resolved
 
-            expect(await bounty.getStake(flagger.address)).to.equal(parseEther("69")) // paid one reviewer's fee
+            expect(await bounty.stakedWei(flagger.address)).to.equal(parseEther("69")) // paid one reviewer's fee
 
             await advanceToTimestamp(start + VOTE_START + 1000, `${addr(flagger)} tries to flag ${addr(voter)}`)
             await expect(flagger.flag(bounty.address, voter.address)).to.be.rejectedWith("error_notEnoughStake")
@@ -463,7 +463,7 @@ describe("VoteKickPolicy", (): void => {
             await advanceToTimestamp(start2 + VOTE_START, `Voters vote to KICK ${addr(flagger)}`)
             await Promise.all(voters.map(async (voter) => (await voter.voteOnFlag(bounty.address, flagger.address, VOTE_KICK)).wait()))
 
-            expect(await bounty.getStake(flagger.address)).to.equal("0") // flagger is kicked
+            expect(await bounty.stakedWei(flagger.address)).to.equal("0") // flagger is kicked
 
             await advanceToTimestamp(start2 + VOTE_START + 1000, "Everyone unstakes")
             await expect(target.unstake(bounty.address))
@@ -505,7 +505,7 @@ describe("VoteKickPolicy", (): void => {
             }
 
             // 67(original) - 6(flags) * 5(reviewers) + 1 (where we didn't manage to pick a full reviewer set)
-            expect(await bounty.getStake(flagger.address)).to.equal(parseEther("38"))
+            expect(await bounty.stakedWei(flagger.address)).to.equal(parseEther("38"))
 
             await advanceToTimestamp(start2, `${addr(targets[0])} flags ${addr(flagger)}`)
             await expect(targets[0].flag(bounty.address, flagger.address))
@@ -514,7 +514,7 @@ describe("VoteKickPolicy", (): void => {
             await advanceToTimestamp(start2 + VOTE_START, `Voters vote to KICK ${addr(flagger)}`)
             await Promise.all(targets.slice(1).map(async (voter) => voter.voteOnFlag(bounty.address, flagger.address, VOTE_KICK)))
 
-            expect(await bounty.getStake(flagger.address)).to.equal("0") // flagger is kicked
+            expect(await bounty.stakedWei(flagger.address)).to.equal("0") // flagger is kicked
         })
     })
 })

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/deployBounty.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/deployBounty.ts
@@ -51,21 +51,21 @@ export async function deployBounty(
     const leavePolicyParam = penaltyPeriodSeconds > -1 ? penaltyPeriodSeconds.toString() : "0"
     const kickPolicyAddress = overrideKickPolicy?.address ?? (adminKickInsteadOfVoteKick ? adminKickPolicy.address : voteKickPolicy.address)
     const kickPolicyParam = "0"
-    const policyAdresses = [allocationPolicyAddress, leavePolicyAddress, kickPolicyAddress]
+    const policyAddresses = [allocationPolicyAddress, leavePolicyAddress, kickPolicyAddress]
     const policyParams = [allocationPolicyParam, leavePolicyParam, kickPolicyParam]
     if (maxBrokerCount > -1) {
-        policyAdresses.push(maxBrokersJoinPolicy.address)
+        policyAddresses.push(maxBrokersJoinPolicy.address)
         policyParams.push(maxBrokerCount.toString())
     }
     if (brokerPoolOnly) {
-        policyAdresses.push(brokerPoolOnlyJoinPolicy.address)
+        policyAddresses.push(brokerPoolOnlyJoinPolicy.address)
         policyParams.push("0")
     }
     if (extraJoinPolicies) {
         assert(extraJoinPolicyParams, "must give extraJoinPolicyParams if giving extraJoinPolicies")
         assert(extraJoinPolicies.length === extraJoinPolicyParams.length, "extraJoinPolicies and extraJoinPolicyParams must be same length")
         for (let i = 0; i < extraJoinPolicies.length; i++) {
-            policyAdresses.push(extraJoinPolicies[i].address)
+            policyAddresses.push(extraJoinPolicies[i].address)
             policyParams.push(extraJoinPolicyParams[i])
         }
     }
@@ -75,7 +75,7 @@ export async function deployBounty(
         minBrokerCount.toString(),
         `Bounty-${bountyCounter++}-${Date.now()}`,
         "metadata",
-        policyAdresses,
+        policyAddresses,
         policyParams
     )
     const bountyDeployReceipt = await bountyDeployTx.wait() as ContractReceipt

--- a/packages/network-contracts/test/hardhat/Registries/ENScache.test.ts
+++ b/packages/network-contracts/test/hardhat/Registries/ENScache.test.ts
@@ -16,11 +16,11 @@ describe("ENSCache", async (): Promise<void> => {
     let minimalForwarderFromAdmin: MinimalForwarder
     // let minimalForwarderFromUser0: MinimalForwarder
     let registryFromAdmin: StreamRegistry
-    let adminAdress: string
+    let adminAddress: string
 
     before(async (): Promise<void> => {
         wallets = await ethers.getSigners()
-        adminAdress = wallets[0].address
+        adminAddress = wallets[0].address
         // Deploy contracs
         const minimalForwarderFromAdminFactory = await ethers.getContractFactory(
             ForwarderJson.abi,
@@ -43,13 +43,13 @@ describe("ENSCache", async (): Promise<void> => {
         )
         oracleFromAdmin = (await oracleFromAdminFactory.deploy(linkTokenFromAdmin.address)) as Oracle
         await oracleFromAdmin.deployed()
-        await oracleFromAdmin.setFulfillmentPermission(adminAdress, true)
+        await oracleFromAdmin.setFulfillmentPermission(adminAddress, true)
         const ensCacheFromAdminFactory = await ethers.getContractFactory(
             ENSCacheJson.abi,
             ENSCacheJson.bytecode,
             wallets[0]
         )
-        ensCacheFromAdmin = (await ensCacheFromAdminFactory.deploy(adminAdress, "jobid")) as ENSCache
+        ensCacheFromAdmin = (await ensCacheFromAdminFactory.deploy(adminAddress, "jobid")) as ENSCache
         await ensCacheFromAdmin.deployed()
 
         await ensCacheFromAdmin.setChainlinkTokenAddress(linkTokenFromAdmin.address)
@@ -71,16 +71,16 @@ describe("ENSCache", async (): Promise<void> => {
         const tx = await ensCacheFromAdmin.requestENSOwner("ensdomain1")
         const tr = await tx.wait()
         const requestId = tr.logs[0].topics[1]
-        await expect(ensCacheFromAdmin.fulfillENSOwner(requestId, utils.hexZeroPad(adminAdress, 32)))
+        await expect(ensCacheFromAdmin.fulfillENSOwner(requestId, utils.hexZeroPad(adminAddress, 32)))
             .to.emit(ensCacheFromAdmin, "ChainlinkFulfilled")
             .and.to.not.emit(registryFromAdmin, "StreamCreated")
     })
 
     it("updates the cache entry and creates a stream: requestENSOwnerAndCreateStream", async () => {
-        const tx = await ensCacheFromAdmin.requestENSOwnerAndCreateStream("ensdomain1", "/path", "metadata", adminAdress)
+        const tx = await ensCacheFromAdmin.requestENSOwnerAndCreateStream("ensdomain1", "/path", "metadata", adminAddress)
         const tr = await tx.wait()
         const requestId = tr.logs[0].topics[1]
-        await expect(ensCacheFromAdmin.fulfillENSOwner(requestId, utils.hexZeroPad(adminAdress, 32))).to.emit(registryFromAdmin, "StreamCreated")
+        await expect(ensCacheFromAdmin.fulfillENSOwner(requestId, utils.hexZeroPad(adminAddress, 32))).to.emit(registryFromAdmin, "StreamCreated")
     })
 
     // TODO: ENSCache is not meta-transaction ready right now
@@ -93,11 +93,11 @@ describe("ENSCache", async (): Promise<void> => {
     //     const data = await ensCacheFromAdmin.interface.encodeFunctionData('requestENSOwner', ['ensdomain1'])
 
     //     const req = {
-    //         from: adminAdress,
+    //         from: adminAddress,
     //         to: ensCacheFromAdmin.address,
     //         value: '0',
     //         gas: '100000',
-    //         nonce: (await minimalForwarderFromAdmin.getNonce(adminAdress)).toString(),
+    //         nonce: (await minimalForwarderFromAdmin.getNonce(adminAddress)).toString(),
     //         data
     //     }
     //     const sign = ethSigUtil.signTypedMessage(utils.arrayify(wallets[0].privateKey),

--- a/packages/network-contracts/test/hardhat/Registries/StreamRegistry.test.ts
+++ b/packages/network-contracts/test/hardhat/Registries/StreamRegistry.test.ts
@@ -65,7 +65,7 @@ describe("StreamRegistry", async (): Promise<void> => {
     let MAX_INT: BigNumber
     let blocktime: number
     // let registryFromUser1: StreamRegistry
-    let adminAdress: string 
+    let adminAddress: string
     let user0Address: string
     let user1Address: string
     let trustedAddress: string
@@ -80,13 +80,13 @@ describe("StreamRegistry", async (): Promise<void> => {
 
     before(async (): Promise<void> => {
         wallets = await ethers.getSigners()
-        adminAdress = wallets[0].address
+        adminAddress = wallets[0].address
         user0Address = wallets[1].address
         user1Address = wallets[2].address
         trustedAddress = wallets[3].address
-        streamId0 = adminAdress.toLowerCase() + streamPath0
-        streamId1 = adminAdress.toLowerCase() + streamPath1
-        streamId2 = adminAdress.toLowerCase() + streamPath2
+        streamId0 = adminAddress.toLowerCase() + streamPath0
+        streamId1 = adminAddress.toLowerCase() + streamPath1
+        streamId2 = adminAddress.toLowerCase() + streamPath2
         const minimalForwarderFromUser0Factory = await ethers.getContractFactory("MinimalForwarder", wallets[9])
         minimalForwarderFromUser0 = await minimalForwarderFromUser0Factory.deploy() as MinimalForwarder
         const streamRegistryFactoryV2 = await ethers.getContractFactory("StreamRegistryV2", wallets[0])
@@ -121,7 +121,7 @@ describe("StreamRegistry", async (): Promise<void> => {
             .to.emit(registryFromAdmin, "StreamCreated")
             .withArgs(streamId0, metadata0)
             .to.emit(registryFromAdmin, "PermissionUpdated")
-            .withArgs(streamId0, adminAdress, true, true, MAX_INT, MAX_INT, true)
+            .withArgs(streamId0, adminAddress, true, true, MAX_INT, MAX_INT, true)
         expect(await registryFromAdmin.streamIdToMetadata(streamId0)).to.equal(metadata0)
     })
 
@@ -182,7 +182,7 @@ describe("StreamRegistry", async (): Promise<void> => {
 
     it("positivetest createStreamWithPermissions", async (): Promise<void> => {
         const newStreamPath = "/" + Wallet.createRandom().address
-        const newStreamId = adminAdress.toLowerCase() + newStreamPath
+        const newStreamId = adminAddress.toLowerCase() + newStreamPath
         const permissionA = {
             canEdit: true,
             canDelete: false,
@@ -198,24 +198,24 @@ describe("StreamRegistry", async (): Promise<void> => {
             canGrant: false
         }
         await expect(await registryFromAdmin.createStreamWithPermissions(newStreamPath, metadata1,
-            [adminAdress, trustedAddress], [permissionA, permissionB]))
+            [adminAddress, trustedAddress], [permissionA, permissionB]))
             // [trustedAddress], [permissionB]))
             .to.emit(registryFromAdmin, "StreamCreated")
             .withArgs(newStreamId, metadata1)
             .to.emit(registryFromAdmin, "PermissionUpdated")
-            .withArgs(newStreamId, adminAdress, true, true, MAX_INT, MAX_INT, true)
+            .withArgs(newStreamId, adminAddress, true, true, MAX_INT, MAX_INT, true)
             .to.emit(registryFromAdmin, "PermissionUpdated")
-            .withArgs(newStreamId, adminAdress, true, false, MAX_INT, MAX_INT, true)
+            .withArgs(newStreamId, adminAddress, true, false, MAX_INT, MAX_INT, true)
             .to.emit(registryFromAdmin, "PermissionUpdated")
             .withArgs(newStreamId, trustedAddress, false, false, 7, 7, false)
         expect(await registryFromAdmin.getStreamMetadata(newStreamId)).to.equal(metadata1)
     })
 
     it("positivetest createMultipleStreamsWithPermissions", async (): Promise<void> => {
-        const newStreamPath1 = "/" + Wallet.createRandom().address 
+        const newStreamPath1 = "/" + Wallet.createRandom().address
         const newStreamPath2 = "/" + Wallet.createRandom().address
-        const newStreamId1 = adminAdress.toLowerCase() + newStreamPath1
-        const newStreamId2 = adminAdress.toLowerCase() + newStreamPath2
+        const newStreamId1 = adminAddress.toLowerCase() + newStreamPath1
+        const newStreamId2 = adminAddress.toLowerCase() + newStreamPath2
         const permissionA = {
             canEdit: true,
             canDelete: false,
@@ -231,20 +231,20 @@ describe("StreamRegistry", async (): Promise<void> => {
             canGrant: false
         }
         await expect(await registryFromAdmin.createMultipleStreamsWithPermissions(
-            [newStreamPath1, newStreamPath2], [metadata1, metadata1], [[adminAdress, trustedAddress],
-                [adminAdress, trustedAddress]], [[permissionA, permissionB], [permissionA, permissionB]]))
+            [newStreamPath1, newStreamPath2], [metadata1, metadata1], [[adminAddress, trustedAddress],
+                [adminAddress, trustedAddress]], [[permissionA, permissionB], [permissionA, permissionB]]))
             .to.emit(registryFromAdmin, "StreamCreated")
             .withArgs(newStreamId1, metadata1)
             .to.emit(registryFromAdmin, "StreamCreated")
             .withArgs(newStreamId2, metadata1)
             .to.emit(registryFromAdmin, "PermissionUpdated")
-            .withArgs(newStreamId1, adminAdress, true, true, MAX_INT, MAX_INT, true)
+            .withArgs(newStreamId1, adminAddress, true, true, MAX_INT, MAX_INT, true)
             .to.emit(registryFromAdmin, "PermissionUpdated")
-            .withArgs(newStreamId2, adminAdress, true, true, MAX_INT, MAX_INT, true)
+            .withArgs(newStreamId2, adminAddress, true, true, MAX_INT, MAX_INT, true)
             .to.emit(registryFromAdmin, "PermissionUpdated")
-            .withArgs(newStreamId1, adminAdress, true, false, MAX_INT, MAX_INT, true)
+            .withArgs(newStreamId1, adminAddress, true, false, MAX_INT, MAX_INT, true)
             .to.emit(registryFromAdmin, "PermissionUpdated")
-            .withArgs(newStreamId2, adminAdress, true, false, MAX_INT, MAX_INT, true)
+            .withArgs(newStreamId2, adminAddress, true, false, MAX_INT, MAX_INT, true)
             .to.emit(registryFromAdmin, "PermissionUpdated")
             .withArgs(newStreamId1, trustedAddress, false, false, 7, 7, false)
             .to.emit(registryFromAdmin, "PermissionUpdated")
@@ -278,20 +278,20 @@ describe("StreamRegistry", async (): Promise<void> => {
     })
 
     it("positivetest getDirectPermissionForUser", async (): Promise<void> => {
-        expect(await registryFromAdmin.getDirectPermissionsForUser(streamId0, adminAdress))
+        expect(await registryFromAdmin.getDirectPermissionsForUser(streamId0, adminAddress))
             .to.deep.equal([true, true, MAX_INT, MAX_INT, true])
     })
 
     it("positivetest getPermissionForUser", async (): Promise<void> => {
-        expect(await registryFromAdmin.getPermissionsForUser(streamId0, adminAdress))
+        expect(await registryFromAdmin.getPermissionsForUser(streamId0, adminAddress))
             .to.deep.equal([true, true, MAX_INT, MAX_INT, true])
     })
 
     it("negativetest getPermissionForUser, stream not exist, userentry not exist", async (): Promise<void> => {
-        await expect(registryFromAdmin.getPermissionsForUser(streamId1, adminAdress))
+        await expect(registryFromAdmin.getPermissionsForUser(streamId1, adminAddress))
             .to.be.revertedWith("error_streamDoesNotExist")
         const res = await registryFromAdmin.getPermissionsForUser(streamId0, user0Address)
-        expect(res.toString()).to.equal([false, false, BigNumber.from(0), BigNumber.from(0), 
+        expect(res.toString()).to.equal([false, false, BigNumber.from(0), BigNumber.from(0),
             false].toString())
     })
 
@@ -326,7 +326,7 @@ describe("StreamRegistry", async (): Promise<void> => {
     })
 
     it("negativetest setPermissionForUser, stream doesnt exist, error_noSharePermission", async (): Promise<void> => {
-        await expect(registryFromAdmin.getPermissionsForUser(streamId0, adminAdress))
+        await expect(registryFromAdmin.getPermissionsForUser(streamId0, adminAddress))
             .to.be.revertedWith("error_streamDoesNotExist")
         await registryFromAdmin.createStream(streamPath0, metadata0)
         await expect(registryFromUser0.setPermissionsForUser(streamId0, user0Address, true, true, 0, 0, true))
@@ -661,12 +661,12 @@ describe("StreamRegistry", async (): Promise<void> => {
     })
 
     it("positivetest transferAllPermissionsToUser", async (): Promise<void> => {
-        expect((await registryFromAdmin.getPermissionsForUser(streamId0, adminAdress)).toString())
+        expect((await registryFromAdmin.getPermissionsForUser(streamId0, adminAddress)).toString())
             .to.equal([true, true, BigNumber.from(MAX_INT), BigNumber.from(MAX_INT), true].toString())
         expect((await registryFromAdmin.getPermissionsForUser(streamId0, user1Address)).toString())
             .to.equal([false, false, BigNumber.from(0), BigNumber.from(0), false].toString())
         await registryFromAdmin.transferAllPermissionsToUser(streamId0, user1Address)
-        expect((await registryFromAdmin.getPermissionsForUser(streamId0, adminAdress)).toString())
+        expect((await registryFromAdmin.getPermissionsForUser(streamId0, adminAddress)).toString())
             .to.equal([false, false, BigNumber.from(0), BigNumber.from(0), false].toString())
         expect((await registryFromAdmin.getPermissionsForUser(streamId0, user1Address)).toString())
             .to.equal([true, true, BigNumber.from(MAX_INT), BigNumber.from(MAX_INT), true].toString())
@@ -800,7 +800,7 @@ describe("StreamRegistry", async (): Promise<void> => {
         const tx2 = await tx.wait()
         expect(tx2.logs.length).to.equal(2)
         //internal call will have failed
-        const id = adminAdress.toLowerCase() + path
+        const id = adminAddress.toLowerCase() + path
         await expect(registryFromAdmin.getStreamMetadata(id)).to.be.revertedWith("error_streamDoesNotExist")
     })
 
@@ -822,7 +822,7 @@ describe("StreamRegistry", async (): Promise<void> => {
         const tx = await minimalForwarderFromUser0.execute(req, sign)
         const tx2 = await tx.wait()
         expect(tx2.logs.length).to.equal(0)
-        const id = adminAdress.toLowerCase() + path
+        const id = adminAddress.toLowerCase() + path
         await expect(registryFromAdmin.getStreamMetadata(id))
             .to.be.revertedWith("error_streamDoesNotExist")
     })
@@ -885,11 +885,11 @@ describe("StreamRegistry", async (): Promise<void> => {
     })
 
     it("positivetest grantRole, revokerole", async (): Promise<void> => {
-        await registryFromAdmin.grantRole(await registryFromAdmin.TRUSTED_ROLE(), adminAdress)
-        expect(await registryFromAdmin.hasRole(await registryFromAdmin.TRUSTED_ROLE(), adminAdress))
+        await registryFromAdmin.grantRole(await registryFromAdmin.TRUSTED_ROLE(), adminAddress)
+        expect(await registryFromAdmin.hasRole(await registryFromAdmin.TRUSTED_ROLE(), adminAddress))
             .to.equal(true)
-        await registryFromAdmin.revokeRole(await registryFromAdmin.TRUSTED_ROLE(), adminAdress)
-        expect(await registryFromAdmin.hasRole(await registryFromAdmin.TRUSTED_ROLE(), adminAdress))
+        await registryFromAdmin.revokeRole(await registryFromAdmin.TRUSTED_ROLE(), adminAddress)
+        expect(await registryFromAdmin.hasRole(await registryFromAdmin.TRUSTED_ROLE(), adminAddress))
             .to.equal(false)
     })
 


### PR DESCRIPTION
LocalStorage is still necessary, to avoid storage clashes for modules, since they would all be laid out in the same area by Solidity

gains/winnings/allocations → earnings
fix typo
removed StakeWeightedAllocationPolicy.getCumulativeWeiPerStake