### PR TITLE
ETH-438: only select "live" BrokerPools as reviewers

### DIFF
--- a/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/VoteKickPolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/VoteKickPolicy.sol
@@ -94,7 +94,7 @@ contract VoteKickPolicy is IKickPolicy, Bounty {
         uint sameBountyPeerCount = 0;
 
         BrokerPoolFactory factory = BrokerPoolFactory(streamrConfig.brokerPoolFactory());
-        uint brokerPoolCount = factory.deployedBrokerPoolsLength();
+        uint brokerPoolCount = factory.liveBrokerPoolCount();
         // uint randomBytes = block.difficulty; // see https://github.com/ethereum/solidity/pull/13759
         bytes32 randomBytes = keccak256(abi.encode(target, brokerPoolCount)); // TODO temporary hack; polygon doesn't seem to support PREVRANDAO yet
 
@@ -104,12 +104,11 @@ contract VoteKickPolicy is IKickPolicy, Bounty {
         for (uint i = 0; i < maxIterations && reviewers[target].length < maxReviewerCount; i++) {
             randomBytes >>= 8; // if flagReviewerCount > 20, replace this with keccak256(randomBytes) or smth
             uint index = uint(randomBytes) % brokerPoolCount;
-            BrokerPool peer = factory.deployedBrokerPools(index);
+            BrokerPool peer = factory.liveBrokerPools(index);
             if (address(peer) == _msgSender() || address(peer) == target || reviewerState[target][peer] != Reviewer.NOT_SELECTED) {
                 // console.log(index, "skipping", address(peer));
                 continue;
             }
-            // TODO: check is broker live
             if (stakedWei[address(peer)] > 0) {
                 if (sameBountyPeerCount + reviewers[target].length < maxReviewerCount) {
                     sameBountyPeers[sameBountyPeerCount++] = peer;

--- a/packages/network-contracts/contracts/BrokerEconomics/BrokerPool.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BrokerPool.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "./IERC677.sol";
 import "./IERC677Receiver.sol";
 import "./IBroker.sol";
+import "./IBrokerPoolLivenessRegistry.sol";
 import "./BrokerPoolPolicies/IPoolJoinPolicy.sol";
 import "./BrokerPoolPolicies/IPoolYieldPolicy.sol";
 import "./BrokerPoolPolicies/IPoolExitPolicy.sol";
@@ -236,10 +237,14 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
         token.approve(address(bounty), amountWei);
         if (indexOfBounties[bounty] == 0) {
             bounty.stake(address(this), amountWei); // may fail if amountWei < minimumStake
-            bounties.push(bounty);
-            indexOfBounties[bounty] = bounties.length; // real array index + 1
             approxPoolValueOfBounty[bounty] += amountWei;
             totalValueInBountiesWei += amountWei;
+
+            bounties.push(bounty);
+            indexOfBounties[bounty] = bounties.length; // real array index + 1
+            if (bounties.length == 1) {
+                try IBrokerPoolLivenessRegistry(streamrConfig.brokerPoolLivenessRegistry()).registerAsLive() {} catch {}
+            }
         }
         emit Staked(bounty, amountWei);
     }
@@ -349,6 +354,9 @@ contract BrokerPool is Initializable, ERC2771ContextUpgradeable, IERC677Receiver
         bounties.pop();
         indexOfBounties[lastBounty] = index + 1; // indexOfBounties is the real array index + 1
         delete indexOfBounties[bounty];
+        if (bounties.length == 0) {
+            try IBrokerPoolLivenessRegistry(streamrConfig.brokerPoolLivenessRegistry()).registerAsNotLive() {} catch {}
+        }
     }
 
     ////////////////////////////////////////

--- a/packages/network-contracts/contracts/BrokerEconomics/BrokerPoolFactory.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BrokerPoolFactory.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
+import "./IBrokerPoolLivenessRegistry.sol";
 import "./BrokerPool.sol";
 import "./IERC677.sol";
 
@@ -15,7 +16,9 @@ import "./IERC677.sol";
  * BrokerPoolFactory creates "smart contract interfaces" for brokers to the Streamr Network.
  * Only BrokerPools from this BrokerPoolFactory can stake to Streamr Network Bounties.
  */
-contract BrokerPoolFactory is Initializable, UUPSUpgradeable, ERC2771ContextUpgradeable, AccessControlUpgradeable {
+contract BrokerPoolFactory is Initializable, UUPSUpgradeable, ERC2771ContextUpgradeable, AccessControlUpgradeable, IBrokerPoolLivenessRegistry {
+    event NewBrokerPool(address poolAddress);
+    event BrokerPoolLivenessChanged(address poolAddress, bool isLive);
 
     bytes32 public constant TRUSTED_FORWARDER_ROLE = keccak256("TRUSTED_FORWARDER_ROLE");
 
@@ -26,12 +29,8 @@ contract BrokerPoolFactory is Initializable, UUPSUpgradeable, ERC2771ContextUpgr
     mapping(address => uint) public deploymentTimestamp; // zero for contracts not deployed by this factory
 
     // array needed for peer broker selection for VoteKickPolicy peer review
-    BrokerPool[] public deployedBrokerPools;
-    function deployedBrokerPoolsLength() public view returns (uint) {
-        return deployedBrokerPools.length;
-    }
-
-    event NewBrokerPool(address poolAddress);
+    BrokerPool[] public liveBrokerPools;
+    mapping (BrokerPool => uint) public liveBrokerPoolsIndex; // real index +1, zero for BrokerPools not staked in a Bounty
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() ERC2771ContextUpgradeable(address(0x0)) {}
@@ -147,10 +146,8 @@ contract BrokerPoolFactory is Initializable, UUPSUpgradeable, ERC2771ContextUpgr
             pool.setExitPolicy(IPoolExitPolicy(policies[2]), initParams[7]);
         }
         pool.renounceRole(pool.DEFAULT_ADMIN_ROLE(), address(this));
+        deploymentTimestamp[poolAddress] = block.timestamp; // solhint-disable-line not-rely-on-time
         emit NewBrokerPool(poolAddress);
-        // solhint-disable-next-line not-rely-on-time
-        deploymentTimestamp[poolAddress] = block.timestamp;
-        deployedBrokerPools.push(pool);
         return poolAddress;
     }
 
@@ -165,5 +162,39 @@ contract BrokerPoolFactory is Initializable, UUPSUpgradeable, ERC2771ContextUpgr
      */
     function isTrustedForwarder(address forwarder) public view override returns (bool) {
         return hasRole(TRUSTED_FORWARDER_ROLE, forwarder);
+    }
+
+    /** BrokerPools MUST call this function when they stake to their first Bounty */
+    function registerAsLive() public {
+        address poolAddress = _msgSender();
+        require(deploymentTimestamp[poolAddress] > 0, "error_onlyBrokerPools");
+        BrokerPool pool = BrokerPool(poolAddress);
+        require(liveBrokerPoolsIndex[pool] == 0, "error_alreadyLive");
+
+        liveBrokerPools.push(pool);
+        liveBrokerPoolsIndex[pool] = liveBrokerPools.length; // real index + 1
+
+        emit BrokerPoolLivenessChanged(poolAddress, true);
+    }
+
+    /** BrokerPools MUST call this function when they unstake from their last Bounty */
+    function registerAsNotLive() public {
+        address poolAddress = _msgSender();
+        require(deploymentTimestamp[poolAddress] > 0, "error_onlyBrokerPools");
+        BrokerPool pool = BrokerPool(poolAddress);
+        require(liveBrokerPoolsIndex[pool] > 0, "error_notLive");
+
+        uint index = liveBrokerPoolsIndex[pool] - 1; // real index = liveBrokerPoolsIndex - 1
+        BrokerPool lastPool = liveBrokerPools[liveBrokerPools.length - 1];
+        liveBrokerPools[index] = lastPool;
+        liveBrokerPools.pop();
+        liveBrokerPoolsIndex[lastPool] = index + 1; // real index + 1
+        delete liveBrokerPoolsIndex[pool];
+
+        emit BrokerPoolLivenessChanged(poolAddress, false);
+    }
+
+    function liveBrokerPoolCount() public view returns (uint) {
+        return liveBrokerPools.length;
     }
 }

--- a/packages/network-contracts/contracts/BrokerEconomics/IBroker.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/IBroker.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-// callbacks supported by the Bounty, for broker smart contracts
+// callbacks supported by the Bounty, for broker smart contracts (BrokerPool)
 interface IBroker {
     function onSlash() external;
     function onKick() external;

--- a/packages/network-contracts/contracts/BrokerEconomics/IBrokerPoolLivenessRegistry.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/IBrokerPoolLivenessRegistry.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+// BrokerPool announces it's live or non-live
+interface IBrokerPoolLivenessRegistry {
+    function registerAsLive() external;
+    function registerAsNotLive() external;
+}

--- a/packages/network-contracts/contracts/BrokerEconomics/StreamrConfig.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/StreamrConfig.sol
@@ -119,6 +119,7 @@ contract StreamrConfig is Initializable, UUPSUpgradeable, AccessControlUpgradeab
 
     address public bountyFactory;
     address public brokerPoolFactory;
+    address public brokerPoolLivenessRegistry; // same as BrokerPoolFactory, for now
 
     /**
      * A mandatory joinpolicy for Bounties from BountyFactory. Ensures only BrokerPools from BrokerPoolFactory can join.
@@ -153,6 +154,7 @@ contract StreamrConfig is Initializable, UUPSUpgradeable, AccessControlUpgradeab
 
     function setBrokerPoolFactory(address brokerPoolFactoryAddress) external onlyRole(DEFAULT_ADMIN_ROLE) {
         brokerPoolFactory = brokerPoolFactoryAddress;
+        brokerPoolLivenessRegistry = brokerPoolFactoryAddress;
     }
 
     function setPoolOnlyJoinPolicy(address poolOnlyJoinPolicyAddress) external onlyRole(DEFAULT_ADMIN_ROLE) {

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/VoteKickPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/VoteKickPolicy.test.ts
@@ -146,8 +146,10 @@ describe("VoteKickPolicy", (): void => {
 
         // live = staked to any Bounty
         it("will only pick live reviewers", async () => {
-            const { bounties, pools: [ flagger, target, voter, nonStaked ], poolFactory } = await setupBounties(contracts, [2, 2], "pick-only-live-reviewers")
-            console.log("factory", contracts.poolFactory.address)
+            const { poolFactory, bounties, pools: [
+                flagger, target, voter, nonStaked
+            ] } = await setupBounties(contracts, [2, 2], "pick-only-live-reviewers")
+
             await expect(nonStaked.unstake(bounties[1].address))
                 .to.emit(poolFactory, "BrokerPoolLivenessChanged").withArgs(nonStaked.address, false)
             await expect(flagger.flag(bounties[0].address, target.address))
@@ -360,7 +362,10 @@ describe("VoteKickPolicy", (): void => {
         })
 
         it("allows the flagger to reduce stake the correct amount DURING the flag period (stake-commited)", async function(): Promise<void> {
-            const { bounties: [ bounty ], poolsPerBounty: [ [flagger, ...targets], [voter] ] } = await setupBounties(contracts, [8, 1], "flagger-reducestake")
+            const {
+                bounties: [ bounty ],
+                poolsPerBounty: [ [flagger, ...targets], [voter] ]
+            } = await setupBounties(contracts, [8, 1], "flagger-reducestake")
 
             await expect(flagger.flag(bounty.address, targets[0].address)).to.emit(voter, "ReviewRequest")
             await expect(flagger.flag(bounty.address, targets[1].address)).to.emit(voter, "ReviewRequest")
@@ -397,7 +402,10 @@ describe("VoteKickPolicy", (): void => {
         })
 
         it("does NOT allow the flagger to flag if he has not enough uncommitted stake", async function(): Promise<void> {
-            const { bounties: [ bounty ], poolsPerBounty: [ [flagger, ...targets], [voter] ] } = await setupBounties(contracts, [8, 1], "super-flagger", {
+            const {
+                bounties: [ bounty ],
+                poolsPerBounty: [ [flagger, ...targets], [voter] ]
+            } = await setupBounties(contracts, [8, 1], "super-flagger", {
                 stakeAmountWei: parseEther("68"), // flag-stake is 10 tokens
             })
             await expect(flagger.flag(bounty.address, targets[0].address)).to.emit(voter, "ReviewRequest")
@@ -410,7 +418,10 @@ describe("VoteKickPolicy", (): void => {
         })
 
         it("does NOT allow the flagger to flag if his stake has been slashed below minimum stake", async function(): Promise<void> {
-            const { bounties: [ bounty ], pools: [ flagger, target, voter ] } = await setupBounties(contracts, [3, 0], "flagger-slashed-below-minimum", {
+            const {
+                bounties: [ bounty ],
+                pools: [ flagger, target, voter ]
+            } = await setupBounties(contracts, [3, 0], "flagger-slashed-below-minimum", {
                 stakeAmountWei: parseEther("70"),
                 bountySettings: {
                     minimumStakeWei: parseEther("70"),

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/VoteKickPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/VoteKickPolicy.test.ts
@@ -3,7 +3,7 @@ import { BigNumber, utils, Wallet } from "ethers"
 import { expect } from "chai"
 
 import { deployTestContracts, TestContracts } from "../deployTestContracts"
-import { setupBounty, BountyTestSetup } from "../setupBounty"
+import { setupBounties, BountyTestSetup } from "../setupBounty"
 import { advanceToTimestamp, getBlockTimestamp, VOTE_KICK, VOTE_NO_KICK, VOTE_START, VOTE_END } from "../utils"
 
 const { parseEther, getAddress, hexZeroPad } = utils
@@ -38,16 +38,17 @@ describe("VoteKickPolicy", (): void => {
         for (const { address } of signers) {
             await (await contracts.token.mint(address, parseEther("1000000"))).wait()
         }
-        defaultBountySetup = await setupBounty(contracts, 3, 2, "default-setup")
+        defaultBountySetup = await setupBounties(contracts, [3, 2], "default-setup")
     })
 
     describe("Flagging + voting + resolution (happy path)", (): void => {
         it("with one flagger, one target and one voter", async function(): Promise<void> {
-            const {
-                token, bounty,
-                staked: [ flagger, target, voter ]
-            } = await setupBounty(contracts, 3, 0, this.test!.title)
             const start = await getBlockTimestamp()
+            const {
+                token,
+                bounties: [ bounty ],
+                pools: [ flagger, target, voter ]
+            } = await setupBounties(contracts, [3], "one-of-each")
 
             await advanceToTimestamp(start, `${addr(flagger)} flags ${addr(target)}`)
             await expect(flagger.flag(bounty.address, target.address))
@@ -61,11 +62,12 @@ describe("VoteKickPolicy", (): void => {
         })
 
         it("with 3 voters", async function(): Promise<void> {
-            const {
-                token, bounty,
-                staked: [ flagger, target, voter1, voter2, voter3 ]
-            } = await setupBounty(contracts, 5, 0, "3-voters-test")
             const start = await getBlockTimestamp()
+            const {
+                token,
+                bounties: [ bounty ],
+                pools: [ flagger, target, voter1, voter2, voter3 ]
+            } = await setupBounties(contracts, [5], "3-voters-test")
 
             await advanceToTimestamp(start, `${addr(flagger)} flags ${addr(target)}`)
             await expect(flagger.flag(bounty.address, target.address))
@@ -88,10 +90,10 @@ describe("VoteKickPolicy", (): void => {
 
         it("with 2 flags active at the same time (not interfere with each other)", async function(): Promise<void> {
             const {
-                token, bounty,
-                staked: [ flagger1, flagger2, target1, target2 ],
-                nonStaked: [ voter ],
-            } = await setupBounty(contracts, 4, 1, "2-active-flags")
+                token,
+                bounties: [ bounty ],
+                pools: [ flagger1, flagger2, target1, target2, voter ],
+            } = await setupBounties(contracts, [4, 1], "2-active-flags")
             const start = await getBlockTimestamp()
 
             await advanceToTimestamp(start, `${addr(target1)} and ${addr(target2)} are flagged`)
@@ -116,40 +118,55 @@ describe("VoteKickPolicy", (): void => {
                 .to.emit(bounty, "BrokerKicked").withArgs(target2.address, parseEther("100"))
 
             // 100 tokens slashing happens to target1,2 pools
-            expect(await token.balanceOf(target1.address)).to.equal(parseEther("901")) // target + voter
-            expect(await token.balanceOf(target2.address)).to.equal(parseEther("901")) // voter + target
+            expect(await token.balanceOf(target1.address)).to.equal(parseEther("901")) // (target +) voter + remaining stake
+            expect(await token.balanceOf(target2.address)).to.equal(parseEther("901")) // voter (+ target) + remaining stake
             expect(await token.balanceOf(flagger1.address)).to.equal(parseEther("2"))  // flagger + voter
             expect(await token.balanceOf(flagger2.address)).to.equal(parseEther("2"))  // voter + flagger
-            expect(await token.balanceOf(voter.address)).to.equal(parseEther("1002"))     // voter + voter
+            expect(await token.balanceOf(voter.address)).to.equal(parseEther("2"))  // voter + voter
         })
     })
 
-    describe("Flagging + reviewer selection", function(): void {
+    describe("Reviewer selection", function(): void {
         it("picks first brokers that are not in the same bounty", async () => {
             const {
-                bounty,
-                staked: [ flagger, target ],
-                nonStaked: [ p4, p5, p6, p7 ]
-            } = await setupBounty(contracts, 5, 4, "pick-first-nonstaked-brokers")
+                bounties: [ bounty ],
+                poolsPerBounty: [
+                    [ flagger, target ],
+                    [ p4, p5, p6, p7 ]
+                ]
+            } = await setupBounties(contracts, [5, 4], "pick-first-nonstaked-brokers")
 
             // all 4 brokers that are not in the same bounty get picked; additionally 1 more from same bounty randomly (but not more!)
-            await expect (flagger.flag(bounty.address, target.address))
+            await expect(flagger.flag(bounty.address, target.address))
                 .to.emit(p4, "ReviewRequest").withArgs(bounty.address, target.address)
                 .to.emit(p5, "ReviewRequest").withArgs(bounty.address, target.address)
                 .to.emit(p6, "ReviewRequest").withArgs(bounty.address, target.address)
                 .to.emit(p7, "ReviewRequest").withArgs(bounty.address, target.address)
         })
 
-        it("can NOT flag if not enough stake", async function(): Promise<void> {
+        // live = staked to any Bounty
+        it("will only pick live reviewers", async () => {
+            const { bounties, pools: [ flagger, target, voter, nonStaked ], poolFactory } = await setupBounties(contracts, [2, 2], "pick-only-live-reviewers")
+            console.log("factory", contracts.poolFactory.address)
+            await expect(nonStaked.unstake(bounties[1].address))
+                .to.emit(poolFactory, "BrokerPoolLivenessChanged").withArgs(nonStaked.address, false)
+            await expect(flagger.flag(bounties[0].address, target.address))
+                .to.emit(voter, "ReviewRequest").withArgs(bounties[0].address, target.address)
+                .to.not.emit(nonStaked, "ReviewRequest")
+        })
+    })
+
+    describe("Flagging", function(): void {
+        it("FAILS if not enough stake", async function(): Promise<void> {
             // TODO: error_notEnoughStake
         })
 
-        it("can NOT flag a broker that is already flagged", async function(): Promise<void> {
+        it("FAILS for a target that is already flagged", async function(): Promise<void> {
             // TODO:
         })
 
-        it("does NOT allow to flag a broker that is not in the bounty", async function(): Promise<void> {
-            const { bounty, staked: [ flagger ], nonStaked: [ notStakedPool ] } = await defaultBountySetup
+        it("FAILS for a target that is not in the bounty", async function(): Promise<void> {
+            const { bounties: [ bounty ], poolsPerBounty: [ [flagger], [notStakedPool] ] } = await defaultBountySetup
             await expect(flagger.flag(bounty.address, notStakedPool.address))
                 .to.be.revertedWith("error_flagTargetNotStaked")
         })
@@ -161,7 +178,7 @@ describe("VoteKickPolicy", (): void => {
         })
 
         it("results in NO_KICK if no one voted", async function(): Promise<void> {
-            const { bounty, staked: [ flagger, target ] } = defaultBountySetup
+            const { bounties: [ bounty ], pools: [ flagger, target ] } = defaultBountySetup
             const start = await getBlockTimestamp()
 
             await advanceToTimestamp(start, `${addr(flagger)} flags ${addr(target)}`)
@@ -187,10 +204,9 @@ describe("VoteKickPolicy", (): void => {
 
         it("pays reviewers who correctly voted NO_KICK even if flagger already was kicked", async function(): Promise<void> {
             const {
-                token, bounty,
-                staked: [ flagger, target ],
-                nonStaked: voters
-            } = await setupBounty(contracts, 2, 5, "flagger-had-been-kicked")
+                token, bounties: [ bounty ],
+                poolsPerBounty: [ [flagger, target], voters ]
+            } = await setupBounties(contracts, [2, 5], "flagger-had-been-kicked")
             const start = await getBlockTimestamp()
 
             await advanceToTimestamp(start, `${addr(flagger)} flags ${addr(target)}`)
@@ -217,19 +233,18 @@ describe("VoteKickPolicy", (): void => {
 
             expect(await bounty.getFlag(target.address)).to.equal("0") // flag is resolved
 
-            expect (await token.balanceOf(voters[0].address)).to.equal(parseEther("1002"))
-            expect (await token.balanceOf(voters[1].address)).to.equal(parseEther("1001"))
-            expect (await token.balanceOf(voters[2].address)).to.equal(parseEther("1001"))
-            expect (await token.balanceOf(voters[3].address)).to.equal(parseEther("1002"))
-            expect (await token.balanceOf(voters[4].address)).to.equal(parseEther("1002"))
+            expect (await token.balanceOf(voters[0].address)).to.equal(parseEther("2"))
+            expect (await token.balanceOf(voters[1].address)).to.equal(parseEther("1"))
+            expect (await token.balanceOf(voters[2].address)).to.equal(parseEther("1"))
+            expect (await token.balanceOf(voters[3].address)).to.equal(parseEther("2"))
+            expect (await token.balanceOf(voters[4].address)).to.equal(parseEther("2"))
         })
 
         it("pays reviewers who correctly voted NO_KICK even if flagger already forceUnstaked", async function(): Promise<void> {
             const {
-                token, bounty,
-                staked: [ flagger, target ],
-                nonStaked: voters
-            } = await setupBounty(contracts, 2, 5, "forceUnstaked-flagger")
+                token, bounties: [ bounty ],
+                poolsPerBounty: [ [flagger, target], voters ]
+            } = await setupBounties(contracts, [2, 5], "forceUnstaked-flagger")
             const start = await getBlockTimestamp()
 
             await advanceToTimestamp(start, `${addr(flagger)} flags ${addr(target)}`)
@@ -251,11 +266,11 @@ describe("VoteKickPolicy", (): void => {
 
             expect(await bounty.getFlag(target.address)).to.equal("0") // flag is resolved
 
-            expect (await token.balanceOf(voters[0].address)).to.equal(parseEther("1001"))
-            expect (await token.balanceOf(voters[1].address)).to.equal(parseEther("1000"))
-            expect (await token.balanceOf(voters[2].address)).to.equal(parseEther("1000"))
-            expect (await token.balanceOf(voters[3].address)).to.equal(parseEther("1001"))
-            expect (await token.balanceOf(voters[4].address)).to.equal(parseEther("1001"))
+            expect (await token.balanceOf(voters[0].address)).to.equal(parseEther("1"))
+            expect (await token.balanceOf(voters[1].address)).to.equal(parseEther("0"))
+            expect (await token.balanceOf(voters[2].address)).to.equal(parseEther("0"))
+            expect (await token.balanceOf(voters[3].address)).to.equal(parseEther("1"))
+            expect (await token.balanceOf(voters[4].address)).to.equal(parseEther("1"))
 
             expect(flaggerBalanceBefore).to.equal("0")
             expect(flaggerBalanceAfter).to.equal(parseEther("990")) // flag-stake was forfeited
@@ -263,10 +278,9 @@ describe("VoteKickPolicy", (): void => {
 
         it("pays reviewers who correctly voted KICK even if target already forceUnstaked", async function(): Promise<void> {
             const {
-                token, bounty,
-                staked: [ flagger, target ],
-                nonStaked: voters
-            } = await setupBounty(contracts, 2, 5, "target-forceUnstake")
+                token, bounties: [ bounty ],
+                poolsPerBounty: [ [flagger, target], voters ]
+            } = await setupBounties(contracts, [2, 5], "target-forceUnstake")
             const start = await getBlockTimestamp()
 
             await advanceToTimestamp(start, `${addr(flagger)} flags ${addr(target)}`)
@@ -288,11 +302,11 @@ describe("VoteKickPolicy", (): void => {
 
             expect(await bounty.getFlag(target.address)).to.equal("0") // flag is resolved
 
-            expect (await token.balanceOf(voters[0].address)).to.equal(parseEther("1001"))
-            expect (await token.balanceOf(voters[1].address)).to.equal(parseEther("1001"))
-            expect (await token.balanceOf(voters[2].address)).to.equal(parseEther("1001"))
-            expect (await token.balanceOf(voters[3].address)).to.equal(parseEther("1000"))
-            expect (await token.balanceOf(voters[4].address)).to.equal(parseEther("1000"))
+            expect (await token.balanceOf(voters[0].address)).to.equal(parseEther("1"))
+            expect (await token.balanceOf(voters[1].address)).to.equal(parseEther("1"))
+            expect (await token.balanceOf(voters[2].address)).to.equal(parseEther("1"))
+            expect (await token.balanceOf(voters[3].address)).to.equal(parseEther("0"))
+            expect (await token.balanceOf(voters[4].address)).to.equal(parseEther("0"))
 
             expect(targetBalanceBefore).to.equal("0")
             expect(targetBalanceAfter).to.equal(parseEther("900")) // 10% stake was forfeited
@@ -301,7 +315,7 @@ describe("VoteKickPolicy", (): void => {
 
     describe("Voting timeline", function(): void {
         it("NO voting before the voting starts", async function(): Promise<void> {
-            const { bounty, staked: [ flagger, target ], nonStaked: [ voter ] } = await setupBounty(contracts, 2, 1, "voting-timeline")
+            const { bounties: [ bounty ], pools: [ flagger, target, voter ] } = await setupBounties(contracts, [2, 1], "voting-timeline")
             await expect(flagger.flag(bounty.address, target.address))
                 .to.emit(voter, "ReviewRequest").withArgs(bounty.address, target.address)
             await expect(voter.voteOnFlag(bounty.address, target.address, VOTE_KICK))
@@ -314,7 +328,7 @@ describe("VoteKickPolicy", (): void => {
 
     describe("Committed stake", (): void => {
         it("allows the target to reduce stake the correct amount DURING the flag period (stake-commited)", async function(): Promise<void> {
-            const { bounty, staked: [ flagger, target ], nonStaked: [ voter ] } = await setupBounty(contracts, 2, 1, "target-reducestake")
+            const { bounties: [ bounty ], pools: [ flagger, target, voter ] } = await setupBounties(contracts, [2, 1], "target-reducestake")
 
             await expect(flagger.flag(bounty.address, target.address))
                 .to.emit(voter, "ReviewRequest").withArgs(bounty.address, target.address)
@@ -328,7 +342,7 @@ describe("VoteKickPolicy", (): void => {
         })
 
         it("allows the target to unstake AFTER the flag resolves to NO_KICK", async function(): Promise<void> {
-            const { bounty, staked: [ flagger, target ], nonStaked: [ voter ] } = await setupBounty(contracts, 2, 1, "target-after-flag")
+            const { bounties: [ bounty ], pools: [ flagger, target, voter ] } = await setupBounties(contracts, [2, 1], "target-after-flag")
             const start = await getBlockTimestamp()
 
             await advanceToTimestamp(start, `${addr(flagger)} flags ${addr(target)}`)
@@ -346,7 +360,7 @@ describe("VoteKickPolicy", (): void => {
         })
 
         it("allows the flagger to reduce stake the correct amount DURING the flag period (stake-commited)", async function(): Promise<void> {
-            const { bounty, staked: [ flagger, ...targets ], nonStaked: [ voter ] } = await setupBounty(contracts, 8, 1, "flagger-reducestake")
+            const { bounties: [ bounty ], poolsPerBounty: [ [flagger, ...targets], [voter] ] } = await setupBounties(contracts, [8, 1], "flagger-reducestake")
 
             await expect(flagger.flag(bounty.address, targets[0].address)).to.emit(voter, "ReviewRequest")
             await expect(flagger.flag(bounty.address, targets[1].address)).to.emit(voter, "ReviewRequest")
@@ -365,7 +379,7 @@ describe("VoteKickPolicy", (): void => {
         })
 
         it("allows the flagger to unstake AFTER the flag resolves to NO_KICK", async function(): Promise<void> {
-            const { bounty, staked: [ flagger, target ], nonStaked: [ voter ] } = await setupBounty(contracts, 2, 1, "flagger-after-flag")
+            const { bounties: [ bounty ], pools: [ flagger, target, voter ] } = await setupBounties(contracts, [2, 1], "flagger-after-flag")
             const start = await getBlockTimestamp()
 
             await advanceToTimestamp(start, `${addr(flagger)} flags ${addr(target)}`)
@@ -383,7 +397,7 @@ describe("VoteKickPolicy", (): void => {
         })
 
         it("does NOT allow the flagger to flag if he has not enough uncommitted stake", async function(): Promise<void> {
-            const { bounty, staked: [ flagger, ...targets ], nonStaked: [ voter ]} = await setupBounty(contracts, 8, 1, "super-flagger", {
+            const { bounties: [ bounty ], poolsPerBounty: [ [flagger, ...targets], [voter] ] } = await setupBounties(contracts, [8, 1], "super-flagger", {
                 stakeAmountWei: parseEther("68"), // flag-stake is 10 tokens
             })
             await expect(flagger.flag(bounty.address, targets[0].address)).to.emit(voter, "ReviewRequest")
@@ -396,7 +410,7 @@ describe("VoteKickPolicy", (): void => {
         })
 
         it("does NOT allow the flagger to flag if his stake has been slashed below minimum stake", async function(): Promise<void> {
-            const { bounty, staked: [ flagger, target, voter ]} = await setupBounty(contracts, 3, 0, "flagger-slashed-below-minimum", {
+            const { bounties: [ bounty ], pools: [ flagger, target, voter ] } = await setupBounties(contracts, [3, 0], "flagger-slashed-below-minimum", {
                 stakeAmountWei: parseEther("70"),
                 bountySettings: {
                     minimumStakeWei: parseEther("70"),
@@ -431,12 +445,11 @@ describe("VoteKickPolicy", (): void => {
 
             const {
                 token,
-                bounty,
-                staked: [ flagger, target ],
-                nonStaked: voters,
-            } = await setupBounty(contracts, 2, reviewerCount, "sufficient-flag-stake", {
+                bounties: [ bounty ],
+                pools: [ flagger, target, ...voters ],
+            } = await setupBounties(contracts, [2, reviewerCount], "sufficient-flag-stake", {
                 bountySettings: { minimumStakeWei },
-                bountyIsRunning: false
+                sponsor: false
             })
             const start = await getBlockTimestamp()
             const start2 = start + VOTE_START + 1000
@@ -481,7 +494,7 @@ describe("VoteKickPolicy", (): void => {
         it("ensures enough tokens to pay reviewers if flagger gets maximally slashed then kicked", async function(): Promise<void> {
             // important that flagStakeWei is at least 10/9 of possible total reviewer rewards
             // because (flagStakeWei - reviewer rewards) * (number of flags) will be left to the flagger after maximal slashing
-            const { bounty, staked: [ flagger, ...targets ] } = await setupBounty(contracts, 7, 0, "extreme-flagger", {
+            const { bounties: [ bounty ], pools: [ flagger, ...targets ] } = await setupBounties(contracts, [7], "extreme-flagger", {
                 stakeAmountWei: parseEther("67"), // flag-stake is 10 tokens
             })
             const start = await getBlockTimestamp()

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/BrokerPool.test.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/BrokerPool.test.ts
@@ -8,7 +8,7 @@ import { deployBrokerPool } from "./deployBrokerPool"
 
 import { deployBounty } from "./deployBounty"
 import { IKickPolicy } from "../../../typechain"
-import { setupBounty } from "./setupBounty"
+import { setupBounties } from "./setupBounty"
 
 const { parseEther, formatEther, hexZeroPad } = utils
 const { getSigners, getContractFactory } = hardhatEthers
@@ -871,9 +871,9 @@ describe("BrokerPool", (): void => {
             await setTokens(broker, "1000")
             await setTokens(delegator, "1000")
             const {
-                bounty,
-                staked: [ flagger, target, voter ]
-            } = await setupBounty(sharedContracts, 3, 0, this.test!.title, { bountyIsRunning: false })
+                bounties: [ bounty ],
+                pools: [ flagger, target, voter ]
+            } = await setupBounties(sharedContracts, [3], this.test!.title, { sponsor: false })
             const start = await getBlockTimestamp()
 
             await advanceToTimestamp(start, "Flag starts")

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/setupBounty.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/setupBounty.ts
@@ -5,36 +5,49 @@ import { deployPoolFactory, TestContracts } from "./deployTestContracts"
 import { deployBounty } from "./deployBounty"
 import { deployBrokerPool } from "./deployBrokerPool"
 
-import type { Bounty, BrokerPool, TestToken } from "../../../typechain"
+import type { Bounty, BrokerPool, BrokerPoolFactory, TestToken } from "../../../typechain"
 
 const { parseEther, id } = utils
 
 export interface BountyTestSetup {
     token: TestToken
-    bounty: Bounty
-    staked: BrokerPool[]
-    nonStaked: BrokerPool[]
+    bounties: Bounty[]
+    pools: BrokerPool[]
+    poolsPerBounty: BrokerPool[][]
+    poolFactory: BrokerPoolFactory
 }
 
 export interface BountyTestSetupOptions {
     bountySettings?: any
     stakeAmountWei?: BigNumber
-    bountyIsRunning?: boolean
+    sponsor?: boolean
+}
+
+function splitBy<T>(arr: T[], counts: number[]): T[][] {
+    const result = []
+    let i = 0
+    for (const count of counts) {
+        result.push(arr.slice(i, i + count))
+        i += count
+    }
+    return result
 }
 
 /**
- * Sets up a Bounty and given number of brokers, each with BrokerPool that stakes 1000 tokens into the Bounty
+ * Sets up a Bounties with given number of brokers staked to each; each with BrokerPool that stakes 1000 tokens into that Bounty
  */
-export async function setupBounty(contracts: TestContracts, stakedBrokerCount = 3, nonStakedBrokerCount = 0, saltSeed: string, {
+export async function setupBounties(contracts: TestContracts, brokerCounts = [0, 3], saltSeed: string, {
     bountySettings = {},
     stakeAmountWei = parseEther("1000"),
-    bountyIsRunning = true,
+    sponsor = true,
 }: BountyTestSetupOptions = {}): Promise<BountyTestSetup> {
     const { token } = contracts
 
     // Hardhat provides 20 pre-funded signers
     const [admin, ...hardhatSigners] = await hardhatEthers.getSigners() as unknown as Wallet[]
-    const signers = hardhatSigners.slice(0, stakedBrokerCount + nonStakedBrokerCount)
+    const totalBrokerCount = brokerCounts.reduce((a, b) => a + b, 0)
+    const bountyCount = brokerCounts.length
+    const signers = hardhatSigners.slice(0, totalBrokerCount)
 
     // clean deployer wallet starts from nothing => needs ether to deploy BrokerPool etc.
     const deployer = new Wallet(id(saltSeed), admin.provider) // id turns string into bytes32
@@ -53,10 +66,7 @@ export async function setupBounty(contracts: TestContracts, stakedBrokerCount = 
     // no risk of nonce collisions in Promise.all since each broker has their own separate nonce
     // see BrokerPoolFactory:_deployBrokerPool for how saltSeed is used in CREATE2
     const pools = await Promise.all(signers.map((signer) => deployBrokerPool(newContracts, signer, {}, saltSeed)))
-    const staked = pools.slice(0, stakedBrokerCount)
-    const nonStaked = pools.slice(stakedBrokerCount, stakedBrokerCount + nonStakedBrokerCount)
-    // console.log("signers: %s", signers.map(addr).join(", "))
-    // console.log("pools: %s", pools.map(addr).join(", "))
+    const poolsPerBounty = splitBy(pools, brokerCounts)
 
     // add broker also as the (only) node, so that flag/vote functions Just Work
     await Promise.all(pools.map(async (pool) => (await pool.setNodeAddresses([await pool.signer.getAddress()])).wait()))
@@ -66,23 +76,29 @@ export async function setupBounty(contracts: TestContracts, stakedBrokerCount = 
         (await token.connect(signer).transferAndCall(pools[i].address, stakeAmountWei, "0x")).wait()
     )))
 
-    const bounty = await deployBounty(contracts, {
-        allocationWeiPerSecond: BigNumber.from(0),
-        penaltyPeriodSeconds: 0,
-        brokerPoolOnly: true,
-        ...bountySettings
-    })
-    if (bountyIsRunning) {
-        await token.approve(bounty.address, parseEther("10000"))
-        await bounty.sponsor(parseEther("10000"))
-    }
+    const bounties: Bounty[] = []
+    for (let i = 0; i < bountyCount; i++) {
+        const stakedPools = poolsPerBounty[i]
+        const bounty = await deployBounty(contracts, {
+            allocationWeiPerSecond: BigNumber.from(0),
+            penaltyPeriodSeconds: 0,
+            brokerPoolOnly: true,
+            ...bountySettings
+        })
+        if (sponsor) {
+            await token.approve(bounty.address, parseEther("10000"))
+            await bounty.sponsor(parseEther("10000"))
+        }
 
-    await Promise.all(staked.map((p) => p.stake(bounty.address, stakeAmountWei)))
+        await Promise.all(stakedPools.map((p) => p.stake(bounty.address, stakeAmountWei)))
+        bounties.push(bounty)
+    }
 
     return {
         token,
-        bounty,
-        staked,
-        nonStaked
+        bounties,
+        pools,
+        poolsPerBounty,
+        poolFactory: newContracts.poolFactory
     }
 }


### PR DESCRIPTION
track "liveness" so that when unstaking from last Bounty, BrokerPool tells
   a registry it's not live anymore

   also tests modified so that now instead of "non-staked" brokers there's
   several Bounties so the previously "non-staked" brokers are simply staked
   in that other Bounty.