### PR TITLE
Clean up registry tests

### DIFF
--- a/packages/network-contracts/contracts/NodeRegistry/NodeRegistry.sol
+++ b/packages/network-contracts/contracts/NodeRegistry/NodeRegistry.sol
@@ -8,9 +8,11 @@ import "@openzeppelin/contracts-upgradeable-4.4.2/proxy/utils/Initializable.sol"
 
 /**
  * @title NodeRegistry
+ *
  * Streamr Network nodes register themselves here
- * @dev OwnableUpgradable contract has an owner address, and provides basic authorization control
- * functions, this simplifies the implementation of "user permissions".
+ *
+ * @dev OwnableUpgradable contract has an owner address, and provides basic authorization control functions.
+ * @dev   This simplifies the implementation of "user permissions".
  */
 contract NodeRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable {
 
@@ -76,10 +78,12 @@ contract NodeRegistry is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     //     return n.node.lastSeen != 0;
     // }
 
+    // TODO: rename to adminCreateOrUpdateNode
     function createOrUpdateNode(address node, string memory metadata_) public onlyOwner {
         _createOrUpdateNode(node, metadata_);
     }
 
+    // TODO: rename to createOrUpdateNode
     function createOrUpdateNodeSelf(string memory metadata_) public whitelistOK {
         _createOrUpdateNode(msg.sender, metadata_);
     }

--- a/packages/network-contracts/contracts/StreamStorageRegistry/StreamStorageRegistry.sol
+++ b/packages/network-contracts/contracts/StreamStorageRegistry/StreamStorageRegistry.sol
@@ -34,7 +34,7 @@ contract StreamStorageRegistry is Initializable, UUPSUpgradeable, ERC2771Context
     }
 
     modifier isTrusted() {
-        require(streamRegistry.hasRole(streamRegistry.getTrustedRole(), _msgSender()), "error_notTrustedRole");
+        require(streamRegistry.hasRole(streamRegistry.getTrustedRole(), _msgSender()), "error_mustBeTrustedRole");
         _;
     }
 

--- a/packages/network-contracts/contracts/StreamStorageRegistry/StreamStorageRegistryV2.sol
+++ b/packages/network-contracts/contracts/StreamStorageRegistry/StreamStorageRegistryV2.sol
@@ -37,7 +37,7 @@ contract StreamStorageRegistryV2 is Initializable, UUPSUpgradeable, ERC2771Conte
     }
 
     modifier isTrusted() {
-        require(streamRegistry.hasRole(streamRegistry.getTrustedRole(), _msgSender()), "error_notTrustedRole");
+        require(streamRegistry.hasRole(streamRegistry.getTrustedRole(), _msgSender()), "error_mustBeTrustedRole");
         _;
     }
 

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/deployTestContracts.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/deployTestContracts.ts
@@ -39,16 +39,15 @@ export async function deployPoolFactory(contracts: Partial<TestContracts>, signe
     await (await poolFactory.initialize(
         poolTemplate!.address,
         token!.address,
-        streamrConfig!.address
+        streamrConfig!.address,
+        { gasLimit: 500000 } // solcover makes the gas estimation require 1000+ ETH for transaction, this fixes it
     )).wait()
     await (await poolFactory.addTrustedPolicies([
         defaultPoolJoinPolicy!.address,
         defaultPoolYieldPolicy!.address,
-        defaultPoolExitPolicy!.address,
-    ])).wait()
-
+        defaultPoolExitPolicy!.address
+    ], { gasLimit: 500000 })).wait()
     await (await streamrConfig!.setBrokerPoolFactory(poolFactory.address)).wait()
-
     return { poolFactory, poolTemplate }
 }
 

--- a/packages/network-contracts/test/hardhat/Registries/StreamStorageRegistry.test.ts
+++ b/packages/network-contracts/test/hardhat/Registries/StreamStorageRegistry.test.ts
@@ -1,318 +1,284 @@
 import { upgrades, ethers } from "hardhat"
 import { expect } from "chai"
+import { Wallet, utils } from "ethers"
+import Debug from "debug"
 
-import type { MinimalForwarder } from "../../../typechain"
-import type { StreamStorageRegistryV2, StreamRegistry, NodeRegistry } from "../../../typechain"
-import { signTypedData, SignTypedDataVersion, TypedMessage } from "@metamask/eth-sig-util"
+import { getEIP2771MetaTx } from "./getEIP2771MetaTx"
 
-// set timeout to 10 minutes
-const types = {
-    EIP712Domain: [
-        {
-            name: "name", type: "string"
-        },
-        {
-            name: "version", type: "string"
-        },
-        {
-            name: "chainId", type: "uint256"
-        },
-        {
-            name: "verifyingContract", type: "address"
-        },
-    ],
-    ForwardRequest: [
-        {
-            name: "from", type: "address"
-        },
-        {
-            name: "to", type: "address"
-        },
-        {
-            name: "value", type: "uint256"
-        },
-        {
-            name: "gas", type: "uint256"
-        },
-        {
-            name: "nonce", type: "uint256"
-        },
-        {
-            name: "data", type: "bytes"
-        },
-    ],
-}
+import type { MinimalForwarder, StreamStorageRegistryV2, StreamRegistry, NodeRegistry } from "../../../typechain"
 
-describe("StreamStorageRegistry", async () => {
-    let streamReg: StreamRegistry
-    let nodeReg: NodeRegistry
-    let reg: StreamStorageRegistryV2
+const { parseEther } = utils
+const log = Debug("Streamr::test::StreamRegistryV4")
+
+describe("StreamStorageRegistry", () => {
+    let registry: StreamStorageRegistryV2
+
+    let streamRegistry: StreamRegistry
+    let nodeRegistry: NodeRegistry
 
     let forwarder: MinimalForwarder
     let forwarderFromMetatxSender: MinimalForwarder
 
-    const wallets = await ethers.getSigners()
-    const [admin, trusted, node0, node1, node2] = wallets
+    let testStreamId: string
 
-    const nodes = [node0, node1, node2]
-    const nodeAddresses = nodes.map((w) => w.address)
-    const nodeUrls = nodes.map((w, i) => `http://node${i}.url`)
-
-    const testStreamId = admin.address.toLowerCase() + "/test"
-
-    const metaTxSender = wallets[5]
+    let wallets: Wallet[]
+    let nodes: Wallet[]
+    let admin: Wallet
+    let trusted: Wallet
+    let node0: Wallet
+    let node1: Wallet
+    let node2: Wallet
+    let metaTxSender: Wallet
 
     before(async () => {
-        // set up nodes
+        wallets = await ethers.getSigners() as unknown[] as Wallet[]
+        ;[, trusted, metaTxSender, ...nodes] = wallets
+        ;[node0, node1, node2] = nodes
+
+        admin = Wallet.createRandom().connect(trusted.provider)
+        await (await trusted.sendTransaction({ to: admin.address, value: parseEther("100") })).wait()
+
+        testStreamId = admin.address.toLowerCase() + "/test"
+
+        const nodeAddresses = nodes.map((w) => w.address)
+        const nodeUrls = nodes.map((w, i) => `http://node${i}.url`)
+
+        log("set up nodes")
         const nodeRegDeploy = await ethers.getContractFactory("NodeRegistry")
         const nodeRegDeployTx = await upgrades.deployProxy(nodeRegDeploy, [admin.address,
             false, nodeAddresses, nodeUrls], {
             kind: "uups"
         })
-        nodeReg = await nodeRegDeployTx.deployed() as NodeRegistry
+        nodeRegistry = await nodeRegDeployTx.deployed() as NodeRegistry
 
-        // set up streams
-        const minimalForwarderFromUser0Factory = await ethers.getContractFactory("MinimalForwarder", wallets[9])
-        forwarder = await minimalForwarderFromUser0Factory.deploy() as MinimalForwarder
+        log("set up streams")
+        const forwarderFromMetatxSenderFactory = await ethers.getContractFactory("MinimalForwarder", wallets[9])
+        forwarder = await forwarderFromMetatxSenderFactory.deploy() as MinimalForwarder
         forwarderFromMetatxSender = forwarder.connect(metaTxSender)
-        const streamRegistryFactory = await ethers.getContractFactory("StreamRegistryV4")
-        const streamRegistryFactoryTx = await upgrades.deployProxy(streamRegistryFactory,
-            ["0x0000000000000000000000000000000000000000", forwarder.address], {
-                kind: "uups"
-            })
-        streamReg = await streamRegistryFactoryTx.deployed() as StreamRegistry
-        await streamReg.createStream("/test", "test-metadata")
-        await streamReg.grantRole(await streamReg.TRUSTED_ROLE(), trusted.address)
+        const streamRegistryFactory = await ethers.getContractFactory("StreamRegistryV4", { signer: admin })
+        const streamRegistryFactoryTx = await upgrades.deployProxy(streamRegistryFactory, [
+            "0x0000000000000000000000000000000000000000",
+            forwarder.address
+        ], { kind: "uups"})
+        streamRegistry = await streamRegistryFactoryTx.deployed() as StreamRegistry
+        await streamRegistry.createStream("/test", "test-metadata")
+        await streamRegistry.grantRole(await streamRegistry.TRUSTED_ROLE(), trusted.address)
 
-        // deploy StreamStorageRegistry
-        const strDeploy = await ethers.getContractFactory("StreamStorageRegistry")
-        const strDeployTx = await upgrades.deployProxy(strDeploy, [streamReg.address, nodeReg.address, forwarder.address], {
-            kind: "uups"
-        })
+        log("deploy StreamStorageRegistry")
+        const strDeploy = await ethers.getContractFactory("StreamStorageRegistry", { signer: admin })
+        const strDeployTx = await upgrades.deployProxy(strDeploy, [
+            streamRegistry.address,
+            nodeRegistry.address,
+            forwarder.address
+        ], { kind: "uups" })
         await strDeployTx.deployed()
 
-        // upgrade to StreamStorageRegistryV2
         // upgrader needs to be trusted as well
-        await streamReg.grantRole(await streamReg.TRUSTED_ROLE(), admin.address)
-        const strV2Deploy = await ethers.getContractFactory("StreamStorageRegistryV2")
+        log("upgrade to StreamStorageRegistryV2")
+        await streamRegistry.grantRole(await streamRegistry.TRUSTED_ROLE(), admin.address)
+        const strV2Deploy = await ethers.getContractFactory("StreamStorageRegistryV2", { signer: admin })
         const strV2DeployTx = await upgrades.upgradeProxy(strDeployTx.address, strV2Deploy, {
             kind: "uups"
         })
-        reg = await strV2DeployTx.deployed() as StreamStorageRegistryV2
-        await streamReg.revokeRole(await streamReg.TRUSTED_ROLE(), admin.address)
+        registry = await strV2DeployTx.deployed() as StreamStorageRegistryV2
+        await streamRegistry.revokeRole(await streamRegistry.TRUSTED_ROLE(), admin.address)
     })
 
     it("can add nodes to a stream", async () => {
-        expect(await reg.isStorageNodeOf(testStreamId, node1.address)).to.be.false
-        await expect(reg.addStorageNode(testStreamId, node1.address))
-            .to.emit(reg, "Added").withArgs(testStreamId, node1.address)
-        expect(await reg.isStorageNodeOf(testStreamId, node1.address)).to.be.true
+        expect(await registry.isStorageNodeOf(testStreamId, node1.address)).to.be.false
+        await expect(registry.addStorageNode(testStreamId, node1.address))
+            .to.emit(registry, "Added").withArgs(testStreamId, node1.address)
+        expect(await registry.isStorageNodeOf(testStreamId, node1.address)).to.be.true
 
         // re-adding emits same events (dateCreated not updated, TODO: test/assert?)
-        await expect(reg.addStorageNode(testStreamId, node1.address))
-            .to.emit(reg, "Added").withArgs(testStreamId, node1.address)
-        expect(await reg.isStorageNodeOf(testStreamId, node1.address)).to.be.true
+        await expect(registry.addStorageNode(testStreamId, node1.address))
+            .to.emit(registry, "Added").withArgs(testStreamId, node1.address)
+        expect(await registry.isStorageNodeOf(testStreamId, node1.address)).to.be.true
 
-        await reg.removeStorageNode(testStreamId, node1.address)
+        await registry.removeStorageNode(testStreamId, node1.address)
     })
 
     it("can remove nodes from a stream", async () => {
-        await reg.addStorageNode(testStreamId, node0.address)
+        await registry.addStorageNode(testStreamId, node0.address)
 
-        expect(await reg.isStorageNodeOf(testStreamId, node0.address)).to.be.true
-        await expect(reg.removeStorageNode(testStreamId, node0.address))
-            .to.emit(reg, "Removed").withArgs(testStreamId, node0.address)
-        expect(await reg.isStorageNodeOf(testStreamId, node0.address)).to.be.false
+        expect(await registry.isStorageNodeOf(testStreamId, node0.address)).to.be.true
+        await expect(registry.removeStorageNode(testStreamId, node0.address))
+            .to.emit(registry, "Removed").withArgs(testStreamId, node0.address)
+        expect(await registry.isStorageNodeOf(testStreamId, node0.address)).to.be.false
     })
 
     it("can add and remove nodes from a stream", async () => {
-        await reg.addStorageNode(testStreamId, node0.address)
-        await expect(reg.addAndRemoveStorageNodes(testStreamId, [nodes[3].address, nodes[4].address], [nodes[0].address, nodes[1].address]))
-            .to.emit(reg, "Added").withArgs(testStreamId, nodes[3].address)
-            .and.emit(reg, "Added").withArgs(testStreamId, nodes[4].address)
-            .and.emit(reg, "Removed").withArgs(testStreamId, nodes[0].address)
-            .and.emit(reg, "Removed").withArgs(testStreamId, nodes[1].address)
-        expect(await reg.isStorageNodeOf(testStreamId, nodes[3].address)).to.be.true
-        expect(await reg.isStorageNodeOf(testStreamId, nodes[4].address)).to.be.true
-        expect(await reg.isStorageNodeOf(testStreamId, nodes[0].address)).to.be.false
-        expect(await reg.isStorageNodeOf(testStreamId, nodes[1].address)).to.be.false
+        await registry.addStorageNode(testStreamId, node0.address)
+        await expect(registry.addAndRemoveStorageNodes(testStreamId, [nodes[3].address, nodes[4].address], [nodes[0].address, nodes[1].address]))
+            .to.emit(registry, "Added").withArgs(testStreamId, nodes[3].address)
+            .and.emit(registry, "Added").withArgs(testStreamId, nodes[4].address)
+            .and.emit(registry, "Removed").withArgs(testStreamId, nodes[0].address)
+            .and.emit(registry, "Removed").withArgs(testStreamId, nodes[1].address)
+        expect(await registry.isStorageNodeOf(testStreamId, nodes[3].address)).to.be.true
+        expect(await registry.isStorageNodeOf(testStreamId, nodes[4].address)).to.be.true
+        expect(await registry.isStorageNodeOf(testStreamId, nodes[0].address)).to.be.false
+        expect(await registry.isStorageNodeOf(testStreamId, nodes[1].address)).to.be.false
     })
 
     it("gives errors for non-existent streams and nodes", async () => {
-        await expect(reg.addStorageNode(testStreamId, admin.address))
+        await expect(registry.addStorageNode(testStreamId, admin.address))
             .to.be.revertedWith("error_storageNodeNotRegistered")
-        await expect(reg.addStorageNode("foo-bar", node0.address))
+        await expect(registry.addStorageNode("foo-bar", node0.address))
             .to.be.revertedWith("error_streamDoesNotExist")
 
-        await expect(reg.addAndRemoveStorageNodes(testStreamId, [admin.address], []))
+        await expect(registry.addAndRemoveStorageNodes(testStreamId, [admin.address], []))
             .to.be.revertedWith("error_storageNodeNotRegistered")
-        await expect(reg.addAndRemoveStorageNodes("foo-bar", [], []))
+        await expect(registry.addAndRemoveStorageNodes("foo-bar", [], []))
             .to.be.revertedWith("error_streamDoesNotExist")
     })
 
     it("will only modify nodes on sender's own streams", async () => {
         const testStreamId2 = node0.address.toLowerCase() + "/test3"
-        await streamReg.connect(node0).createStream("/test3", "test3-metadata")
-        await expect(reg.addStorageNode(testStreamId2, node0.address))
+        await streamRegistry.connect(node0).createStream("/test3", "test3-metadata")
+        await expect(registry.addStorageNode(testStreamId2, node0.address))
             .to.be.revertedWith("error_noEditPermission")
-        await expect(reg.removeStorageNode(testStreamId2, node0.address))
+        await expect(registry.removeStorageNode(testStreamId2, node0.address))
             .to.be.revertedWith("error_noEditPermission")
-        await expect(reg.addAndRemoveStorageNodes(testStreamId2, [], []))
+        await expect(registry.addAndRemoveStorageNodes(testStreamId2, [], []))
             .to.be.revertedWith("error_noEditPermission")
     })
 
     it("removed nodes and streams aren't returned by isStorageNodeOf", async () => {
         const testStreamId2 = admin.address.toLowerCase() + "/test2"
-        await streamReg.createStream("/test2", "test2-metadata")
+        await streamRegistry.createStream("/test2", "test2-metadata")
 
-        await reg.addStorageNode(testStreamId2, node0.address)
-        await reg.addStorageNode(testStreamId, node2.address)
+        await registry.addStorageNode(testStreamId2, node0.address)
+        await registry.addStorageNode(testStreamId, node2.address)
 
-        expect(await reg.isStorageNodeOf(testStreamId2, node0.address)).to.be.true
-        await streamReg.deleteStream(testStreamId2)
-        expect(await reg.isStorageNodeOf(testStreamId2, node0.address)).to.be.false
+        expect(await registry.isStorageNodeOf(testStreamId2, node0.address)).to.be.true
+        await streamRegistry.deleteStream(testStreamId2)
+        expect(await registry.isStorageNodeOf(testStreamId2, node0.address)).to.be.false
 
-        expect(await reg.isStorageNodeOf(testStreamId, node2.address)).to.be.true
-        await nodeReg.removeNode(node2.address)
-        expect(await reg.isStorageNodeOf(testStreamId, node2.address)).to.be.false
+        expect(await registry.isStorageNodeOf(testStreamId, node2.address)).to.be.true
+        await nodeRegistry.connect(node2).removeNodeSelf()
+        expect(await registry.isStorageNodeOf(testStreamId, node2.address)).to.be.false
+
+        log("Clean up")
+        await nodeRegistry.connect(node2).createOrUpdateNodeSelf("http://node2.url")
     })
 
     it("allows TRUSTED_ROLE address to add and remove nodes", async () => {
-        const r = reg.connect(trusted)
+        const r = registry.connect(trusted)
         await expect(r.addStorageNode(testStreamId, node1.address))
-            .to.emit(reg, "Added").withArgs(testStreamId, node1.address)
+            .to.emit(registry, "Added").withArgs(testStreamId, node1.address)
         expect(await r.isStorageNodeOf(testStreamId, node1.address)).to.be.true
 
         await expect(r.removeStorageNode(testStreamId, node1.address))
-            .to.emit(reg, "Removed").withArgs(testStreamId, node1.address)
+            .to.emit(registry, "Removed").withArgs(testStreamId, node1.address)
         expect(await r.isStorageNodeOf(testStreamId, node1.address)).to.be.false
 
         await expect(r.addAndRemoveStorageNodes(testStreamId, [nodes[0].address, nodes[1].address], [nodes[2].address, nodes[3].address]))
-            .to.emit(reg, "Added").withArgs(testStreamId, nodes[0].address)
-            .and.emit(reg, "Added").withArgs(testStreamId, nodes[1].address)
-            .and.emit(reg, "Removed").withArgs(testStreamId, nodes[2].address)
-            .and.emit(reg, "Removed").withArgs(testStreamId, nodes[3].address)
+            .to.emit(registry, "Added").withArgs(testStreamId, nodes[0].address)
+            .and.emit(registry, "Added").withArgs(testStreamId, nodes[1].address)
+            .and.emit(registry, "Removed").withArgs(testStreamId, nodes[2].address)
+            .and.emit(registry, "Removed").withArgs(testStreamId, nodes[3].address)
         expect(await r.isStorageNodeOf(testStreamId, nodes[0].address)).to.be.true
         expect(await r.isStorageNodeOf(testStreamId, nodes[1].address)).to.be.true
         expect(await r.isStorageNodeOf(testStreamId, nodes[2].address)).to.be.false
         expect(await r.isStorageNodeOf(testStreamId, nodes[3].address)).to.be.false
     })
 
-    async function prepareMetatx(forwarder: MinimalForwarder, signKey: string, gas?: string) {
-        // admin is creating and signing transaction, user0 is posting it and paying for gas
-        const data = await reg.interface.encodeFunctionData("addStorageNode", [testStreamId, node1.address])
-        const req = {
-            from: admin.address,
-            to: reg.address,
-            value: "0",
-            gas: gas ? gas : "1000000",
-            nonce: (await forwarder.getNonce(admin.address)).toString(),
-            data
+    describe("EIP-2771 meta-transactions feature", () => {
+        async function getAddStorageNodeMetaTx({
+            forwarder = forwarderFromMetatxSender,
+            signer = admin,
+            gas
+        }: { forwarder?: MinimalForwarder; signer?: Wallet; gas?: string } = {}) {
+            // admin is creating and signing transaction, user0 is posting it and paying for gas
+            const data = await registry.interface.encodeFunctionData("addStorageNode", [testStreamId, node1.address])
+            const { request, signature } = await getEIP2771MetaTx(registry.address, data, forwarder, signer, gas)
+            return { request, signature }
         }
-        const d: TypedMessage<any> = {
-            types,
-            domain: {
-                name: "MinimalForwarder",
-                version: "0.0.1",
-                chainId: (await ethers.provider.getNetwork()).chainId,
-                verifyingContract: forwarder.address,
-            },
-            primaryType: "ForwardRequest",
-            message: req,
-        }
-        const options = {
-            data: d,
-            privateKey: ethers.utils.arrayify(signKey) as Buffer,
-            version: SignTypedDataVersion.V4,
-        }
-        const sign = signTypedData(options) // user0
-        return {req, sign}
-    }
 
-    it("positivetest metatransaction", async (): Promise<void> => {
-        // admin is creating and signing transaction, sender is posting it and paying for gas
-        await reg.removeStorageNode(testStreamId, node1.address)
-        expect(await reg.isStorageNodeOf(testStreamId, node1.address)).to.be.false
-        
-        const {req, sign} = await prepareMetatx(forwarderFromMetatxSender, admin.privateKey)
-        const res = await forwarderFromMetatxSender.verify(req, sign)
-        await expect(res).to.be .true
-        const tx = await forwarderFromMetatxSender.execute(req, sign)
-        const tx2 = await tx.wait()
-        expect(tx2.logs.length).to.equal(1)
+        it("works as expected (happy path)", async (): Promise<void> => {
+            log("Add storage node using meta-transaction")
+            const { request, signature } = await getAddStorageNodeMetaTx()
+            const signatureIsValid = await forwarderFromMetatxSender.verify(request, signature)
+            await expect(signatureIsValid).to.be.true
+            await (await forwarderFromMetatxSender.execute(request, signature)).wait()
 
-        expect(await reg.isStorageNodeOf(testStreamId, node1.address)).to.be.true
-    })
+            expect(await registry.isStorageNodeOf(testStreamId, node1.address)).to.be.true
 
-    it("negativetest metatransaction, wrong forwarder", async (): Promise<void> => {
-        await reg.removeStorageNode(testStreamId, node1.address)
-        expect(await reg.isStorageNodeOf(testStreamId, node1.address)).to.be.false
-        // deploy second minimal forwarder
-        const minimalForwarderFromUser0Factory = await ethers.getContractFactory("MinimalForwarder", wallets[9])
-        const wrongFrowarder = await minimalForwarderFromUser0Factory.deploy() as MinimalForwarder
-        await wrongFrowarder.deployed()
-        // check that forwarder is set
-        expect(await reg.isTrustedForwarder(forwarderFromMetatxSender.address)).to.be.true
-        expect(await reg.isTrustedForwarder(wrongFrowarder.address)).to.be.false
-        // check that metatx works with new forwarder
-        const {req, sign} = await prepareMetatx(wrongFrowarder, admin.privateKey)
-        const res = await wrongFrowarder.verify(req, sign)
-        await expect(res).to.be.true
-        const tx = await wrongFrowarder.execute(req, sign)
-        const tx2 = await tx.wait()
-        expect(tx2.logs.length).to.equal(0)
-        //internal call will have failed
-        expect(await reg.isStorageNodeOf(testStreamId, node1.address)).to.be.false
+            log("Clean up")
+            await registry.removeStorageNode(testStreamId, node1.address)
+        })
 
-    })
+        it("FAILS with wrong forwarder (negativetest)", async (): Promise<void> => {
+            log("Deploy second minimal forwarder")
+            const forwarderFromMetatxSenderFactory = await ethers.getContractFactory("MinimalForwarder", wallets[9])
+            const wrongForwarder = await forwarderFromMetatxSenderFactory.deploy() as MinimalForwarder
+            await wrongForwarder.deployed()
 
-    it("negativetest metatransaction, wrong signature", async (): Promise<void> => {
-        const wrongKey = wallets[2].privateKey //wallets[0].privateKey (admin) would be correct
-        const {req, sign} = await prepareMetatx(forwarderFromMetatxSender, wrongKey)
-        const res = await forwarderFromMetatxSender.verify(req, sign)
-        await expect(res).to.be.false
-        await expect(forwarderFromMetatxSender.execute(req, sign))
-            .to.be.revertedWith("MinimalForwarder: signature does not match request")
-    })
+            log("Check that the correct forwarder is set")
+            expect(await registry.isTrustedForwarder(forwarderFromMetatxSender.address)).to.be.true
+            expect(await registry.isTrustedForwarder(wrongForwarder.address)).to.be.false
 
-    it("negativetest metatransaction not enough gas in internal transaction call", async (): Promise<void> => {
-        await reg.removeStorageNode(testStreamId, node1.address)
-        expect(await reg.isStorageNodeOf(testStreamId, node1.address)).to.be.false
-        const {req, sign} = await prepareMetatx(forwarderFromMetatxSender, admin.privateKey, "1000")
-        const res = await forwarderFromMetatxSender.verify(req, sign)
-        await expect(res).to.be.true
-        const tx = await forwarderFromMetatxSender.execute(req, sign)
-        const tx2 = await tx.wait()
-        expect(tx2.logs.length).to.equal(0)
-        expect(await reg.isStorageNodeOf(testStreamId, node1.address)).to.be.false
-    })
+            log("Metatx seems to succeed with the wrong forwarder")
+            const { request, signature } = await getAddStorageNodeMetaTx({ forwarder: wrongForwarder })
+            const signatureIsValid = await wrongForwarder.verify(request, signature)
+            await expect(signatureIsValid).to.be.true
+            await (await wrongForwarder.execute(request, signature)).wait()
 
-    it("positivetest reset trusted forwarder, then test metatx", async (): Promise<void> => {
-        await reg.removeStorageNode(testStreamId, node1.address)
-        expect(await reg.isStorageNodeOf(testStreamId, node1.address)).to.be.false
-        // deploy second minimal forwarder
-        const minimalForwarderFromUser0Factory = await ethers.getContractFactory("MinimalForwarder", wallets[9])
-        const newForwarder = await minimalForwarderFromUser0Factory.deploy() as MinimalForwarder
-        await newForwarder.deployed()
-        // set forwarder
-        await streamReg.grantRole(await streamReg.TRUSTED_ROLE(), admin.address)
-        await reg.setTrustedForwarder(newForwarder.address)
-        await streamReg.revokeRole(await streamReg.TRUSTED_ROLE(), admin.address)
-        // check that forwarder is set
-        expect(await reg.isTrustedForwarder(forwarderFromMetatxSender.address)).to.be.false
-        expect(await reg.isTrustedForwarder(newForwarder.address)).to.be.true
-        // check that metatx works with new forwarder
-        const {req, sign} = await prepareMetatx(newForwarder, admin.privateKey)
-        const res = await newForwarder.verify(req, sign)
-        await expect(res).to.be.true
-        const tx = await newForwarder.execute(req, sign)
-        const tx2 = await tx.wait()
-        expect(tx2.logs.length).to.equal(1)
-        expect(await reg.isStorageNodeOf(testStreamId, node1.address)).to.be.true
-    })
+            log("Tx failed, so storage node wasn't added")
+            expect(await registry.isStorageNodeOf(testStreamId, node1.address)).to.be.false
+        })
 
-    it("negativetest reset trusted forwarder, caller not trusted", async (): Promise<void> => {
-        await expect(reg.setTrustedForwarder(ethers.Wallet.createRandom().address))
-            .to.be.revertedWith("error_notTrustedRole")
+        it("FAILS with wrong signature (negativetest)", async (): Promise<void> => {
+            const wrongSigner = ethers.Wallet.createRandom()
+            const { request } = await getAddStorageNodeMetaTx()
+            const { signature } = await getAddStorageNodeMetaTx({ signer: wrongSigner })
+            const signatureIsValid = await forwarderFromMetatxSender.verify(request, signature)
+            await expect(signatureIsValid).to.be.false
+            await expect(forwarderFromMetatxSender.execute(request, signature))
+                .to.be.revertedWith("MinimalForwarder: signature does not match request")
+        })
+
+        it("FAILS with not enough gas in internal transaction call (negativetest)", async (): Promise<void> => {
+            log("Create a valid signature with too little gas for the tx")
+            const { request, signature } = await getAddStorageNodeMetaTx({ gas: "1000" })
+            const signatureIsValid = await forwarderFromMetatxSender.verify(request, signature)
+            await expect(signatureIsValid).to.be.true
+            await (await forwarderFromMetatxSender.execute(request, signature)).wait()
+
+            log("Tx failed, so storage node wasn't added")
+            expect(await registry.isStorageNodeOf(testStreamId, node1.address)).to.be.false
+        })
+
+        it("works after resetting trusted forwarder (positivetest)", async (): Promise<void> => {
+            log("Deploy second minimal forwarder")
+            const forwarderFromMetatxSenderFactory = await ethers.getContractFactory("MinimalForwarder", wallets[9])
+            const newForwarder = await forwarderFromMetatxSenderFactory.deploy() as MinimalForwarder
+            await newForwarder.deployed()
+
+            log("Set new forwarder")
+            await streamRegistry.grantRole(await streamRegistry.TRUSTED_ROLE(), admin.address)
+            await registry.setTrustedForwarder(newForwarder.address)
+
+            log("Check that the correct forwarder is set")
+            expect(await registry.isTrustedForwarder(forwarderFromMetatxSender.address)).to.be.false
+            expect(await registry.isTrustedForwarder(newForwarder.address)).to.be.true
+
+            log("Check that metatx works with new forwarder")
+            const { request, signature } = await getAddStorageNodeMetaTx({ forwarder: newForwarder })
+            const signatureIsValid = await newForwarder.verify(request, signature)
+            await expect(signatureIsValid).to.be.true
+            await (await newForwarder.execute(request, signature)).wait()
+            expect(await registry.isStorageNodeOf(testStreamId, node1.address)).to.be.true
+
+            log("Clean up, set old forwarder back")
+            await registry.removeStorageNode(testStreamId, node1.address)
+            await registry.setTrustedForwarder(forwarderFromMetatxSender.address)
+            await streamRegistry.revokeRole(await streamRegistry.TRUSTED_ROLE(), admin.address)
+        })
+
+        it("PREVENTS resetting trusted forwarder if caller not trusted (negativetest)", async (): Promise<void> => {
+            await expect(registry.setTrustedForwarder(Wallet.createRandom().address))
+                .to.be.revertedWith("error_mustBeTrustedRole")
+        })
     })
 })

--- a/packages/network-contracts/test/hardhat/Registries/getEIP2771MetaTx.ts
+++ b/packages/network-contracts/test/hardhat/Registries/getEIP2771MetaTx.ts
@@ -1,10 +1,22 @@
-import { ethers } from "hardhat";
-import { utils, Wallet } from "ethers";
-import { signTypedData, SignTypedDataVersion, TypedMessage } from "@metamask/eth-sig-util";
-import { MinimalForwarder } from "../../../typechain";
+import { ethers } from "hardhat"
+import { utils, Wallet } from "ethers"
+import { signTypedData, SignTypedDataVersion, TypedMessage } from "@metamask/eth-sig-util"
+import { MinimalForwarder } from "../../../typechain"
+
+interface EIP2771MetaTx {
+    request: {
+        from: string
+        to: string
+        value: string
+        gas: string
+        nonce: string
+        data: string
+    }
+    signature: string
+}
 
 /** @dev see https://eips.ethereum.org/EIPS/eip-2771 */
-export async function getEIP2771MetaTx(to: string, data: string, forwarder: MinimalForwarder, signer: Wallet, gas?: string) {
+export async function getEIP2771MetaTx(to: string, data: string, forwarder: MinimalForwarder, signer: Wallet, gas?: string): Promise<EIP2771MetaTx> {
     const request = {
         from: signer.address,
         to,
@@ -12,7 +24,7 @@ export async function getEIP2771MetaTx(to: string, data: string, forwarder: Mini
         gas: gas ? gas : "1000000",
         nonce: (await forwarder.getNonce(signer.address)).toString(),
         data
-    };
+    }
     const d: TypedMessage<any> = {
         domain: {
             name: "MinimalForwarder",
@@ -38,12 +50,12 @@ export async function getEIP2771MetaTx(to: string, data: string, forwarder: Mini
                 { name: "data", type: "bytes" },
             ],
         },
-    };
+    }
     const options = {
         data: d,
         privateKey: utils.arrayify(signer.privateKey) as Buffer,
         version: SignTypedDataVersion.V4,
-    };
-    const signature = signTypedData(options); // user0
-    return { request, signature };
+    }
+    const signature = signTypedData(options)
+    return { request, signature }
 }

--- a/packages/network-contracts/test/hardhat/Registries/getEIP2771MetaTx.ts
+++ b/packages/network-contracts/test/hardhat/Registries/getEIP2771MetaTx.ts
@@ -1,0 +1,49 @@
+import { ethers } from "hardhat";
+import { utils, Wallet } from "ethers";
+import { signTypedData, SignTypedDataVersion, TypedMessage } from "@metamask/eth-sig-util";
+import { MinimalForwarder } from "../../../typechain";
+
+/** @dev see https://eips.ethereum.org/EIPS/eip-2771 */
+export async function getEIP2771MetaTx(to: string, data: string, forwarder: MinimalForwarder, signer: Wallet, gas?: string) {
+    const request = {
+        from: signer.address,
+        to,
+        value: "0",
+        gas: gas ? gas : "1000000",
+        nonce: (await forwarder.getNonce(signer.address)).toString(),
+        data
+    };
+    const d: TypedMessage<any> = {
+        domain: {
+            name: "MinimalForwarder",
+            version: "0.0.1",
+            chainId: (await ethers.provider.getNetwork()).chainId,
+            verifyingContract: forwarder.address,
+        },
+        primaryType: "ForwardRequest",
+        message: request,
+        types: {
+            EIP712Domain: [
+                { name: "name", type: "string" },
+                { name: "version", type: "string" },
+                { name: "chainId", type: "uint256" },
+                { name: "verifyingContract", type: "address" },
+            ],
+            ForwardRequest: [
+                { name: "from", type: "address" },
+                { name: "to", type: "address" },
+                { name: "value", type: "uint256" },
+                { name: "gas", type: "uint256" },
+                { name: "nonce", type: "uint256" },
+                { name: "data", type: "bytes" },
+            ],
+        },
+    };
+    const options = {
+        data: d,
+        privateKey: utils.arrayify(signer.privateKey) as Buffer,
+        version: SignTypedDataVersion.V4,
+    };
+    const signature = signTypedData(options); // user0
+    return { request, signature };
+}


### PR DESCRIPTION
I noticed while working on ETH-463 that StreamStorageRegistry.test.ts tests weren't run at all. The code had rot pretty bad. It runs now and all is green. I took most of it from StreamRegistry.test.ts which was being run; but ended up refactoring that too, to pull out the common EIP2771 stuff into a file (had been copy-pasted). Mopped it all up afterwards.

RegistryFromX isn't needed in StreamRegistry.test.ts for getters that don't look at msg.sender at all, it's just noise. Search+replaced those.

pulled EIP2771 meta tx generation to its own file (DRY)

also unified an error message between StreamRegistry and StreamStorageRegistry