### PR TITLE
Bounty events change (ETH-468)

### DIFF
--- a/packages/network-contracts/contracts/BrokerEconomics/Bounty.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/Bounty.sol
@@ -275,8 +275,10 @@ contract Bounty is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, Ac
      * @dev do not slash more than the whole stake!
      */
     function _kick(address broker, uint slashingWei) internal {
-        _reduceStakeBy(broker, slashingWei);
-        emit BrokerSlashed(broker, slashingWei);
+        if (slashingWei > 0) {
+            _reduceStakeBy(broker, slashingWei);
+            emit BrokerSlashed(broker, slashingWei);
+        }
         _removeBroker(broker);
         emit BrokerKicked(broker);
         if (broker.code.length > 0) {

--- a/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/StakeWeightedAllocationPolicy.sol
+++ b/packages/network-contracts/contracts/BrokerEconomics/BountyPolicies/StakeWeightedAllocationPolicy.sol
@@ -224,5 +224,6 @@ contract StakeWeightedAllocationPolicy is IAllocationPolicy, Bounty {
         if (getInsolvencyTimestamp() < block.timestamp) {
             update(amount);
         }
+        emit ProjectedInsolvencyUpdate(getInsolvencyTimestamp());
     }
 }

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/AdminKickPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/AdminKickPolicy.test.ts
@@ -46,12 +46,10 @@ describe("AdminKickPolicy", (): void => {
         await advanceToTimestamp(timeAtStart + 100, "broker 2 joins")
         await (await token.connect(broker2).transferAndCall(bounty.address, parseEther("1000"), broker2.address)).wait()
 
-        // event BrokerKicked(address indexed broker, uint slashedWei);
         const brokerCountBeforeKick = await bounty.brokerCount()
         await advanceToTimestamp(timeAtStart + 200, "broker 1 is kicked out")
         expect (await bounty.connect(admin).flag(await broker.getAddress()))
-            .to.emit(bounty, "BrokerKicked")
-            .withArgs(await broker.getAddress(), "0")
+            .to.emit(bounty, "BrokerKicked").withArgs(await broker.getAddress())
         const brokerCountAfterKick = await bounty.brokerCount()
 
         await advanceToTimestamp(timeAtStart + 300, "broker 2 leaves and gets slashed")
@@ -71,8 +69,7 @@ describe("AdminKickPolicy", (): void => {
 
         const brokerCountBeforeReport = await bounty.brokerCount()
         expect(bounty.connect(broker2).flag(await broker.getAddress()))
-            .to.emit(bounty, "BrokerKicked")
-            .withArgs(await broker.getAddress(), "0")
+            .to.emit(bounty, "BrokerKicked").withArgs(await broker.getAddress())
         const brokerCountAfterReport = await bounty.brokerCount()
 
         expect(brokerCountBeforeReport.toString()).to.equal("1")

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/VoteKickPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/BountyPolicies/VoteKickPolicy.test.ts
@@ -56,7 +56,8 @@ describe("VoteKickPolicy", (): void => {
 
             await advanceToTimestamp(start + VOTE_START, `${addr(flagger)} votes to kick ${addr(target)}`)
             await expect(voter.voteOnFlag(bounty.address, target.address, VOTE_KICK))
-                .to.emit(bounty, "BrokerKicked").withArgs(target.address, parseEther("100"))
+                .to.emit(bounty, "BrokerKicked").withArgs(target.address)
+                .to.emit(bounty, "BrokerSlashed").withArgs(target.address, parseEther("100"))
 
             expect(await token.balanceOf(target.address)).to.equal(parseEther("900")) // slash 10%
         })
@@ -80,7 +81,7 @@ describe("VoteKickPolicy", (): void => {
             await expect(voter2.voteOnFlag(bounty.address, target.address, VOTE_NO_KICK))
                 .to.not.emit(bounty, "BrokerKicked")
             await expect(voter3.voteOnFlag(bounty.address, target.address, VOTE_KICK))
-                .to.emit(bounty, "BrokerKicked").withArgs(target.address, parseEther("100"))
+                .to.emit(bounty, "BrokerKicked").withArgs(target.address)
             expect(await token.balanceOf(target.address)).to.equal(parseEther("900"))
 
             expect (await token.balanceOf(voter1.address)).to.equal(parseEther("1"))
@@ -111,11 +112,8 @@ describe("VoteKickPolicy", (): void => {
             await expect(flagger1.voteOnFlag(bounty.address, target2.address, VOTE_KICK)).to.not.emit(bounty, "BrokerKicked")
             await expect(voter.voteOnFlag(bounty.address, target1.address, VOTE_KICK)).to.not.emit(bounty, "BrokerKicked")
             await expect(voter.voteOnFlag(bounty.address, target2.address, VOTE_KICK)).to.not.emit(bounty, "BrokerKicked")
-
-            await expect(target2.voteOnFlag(bounty.address, target1.address, VOTE_KICK))
-                .to.emit(bounty, "BrokerKicked").withArgs(target1.address, parseEther("100"))
-            await expect(target1.voteOnFlag(bounty.address, target2.address, VOTE_KICK))
-                .to.emit(bounty, "BrokerKicked").withArgs(target2.address, parseEther("100"))
+            await expect(target2.voteOnFlag(bounty.address, target1.address, VOTE_KICK)).to.emit(bounty, "BrokerKicked").withArgs(target1.address)
+            await expect(target1.voteOnFlag(bounty.address, target2.address, VOTE_KICK)).to.emit(bounty, "BrokerKicked").withArgs(target2.address)
 
             // 100 tokens slashing happens to target1,2 pools
             expect(await token.balanceOf(target1.address)).to.equal(parseEther("901")) // (target +) voter + remaining stake

--- a/packages/network-contracts/test/hardhat/BrokerEconomics/BrokerPool.test.ts
+++ b/packages/network-contracts/test/hardhat/BrokerEconomics/BrokerPool.test.ts
@@ -721,7 +721,8 @@ describe("BrokerPool", (): void => {
 
         // TestKickPolicy actually kicks and slashes given amount
         await expect(bounty.connect(admin).voteOnFlag(pool.address, hexZeroPad(parseEther("10").toHexString(), 32)))
-            .to.emit(bounty, "BrokerKicked").withArgs(pool.address, parseEther("10"))
+            .to.emit(bounty, "BrokerKicked").withArgs(pool.address)
+            .to.emit(bounty, "BrokerSlashed").withArgs(pool.address, parseEther("10"))
         expect(await pool.getApproximatePoolValue()).to.equal(parseEther("1990"))
     })
 

--- a/packages/network-subgraphs/src/bounty.ts
+++ b/packages/network-subgraphs/src/bounty.ts
@@ -33,10 +33,9 @@ export function handleStakeUpdated(event: StakeUpdate): void {
 
 export function handleBountyUpdated(event: BountyUpdate): void {
     // log.info('handleBountyUpdated: sidechainaddress={} blockNumber={}', [event.address.toHexString(), event.block.number.toString()])
-    log.info('handleBountyUpdated: totalStakeWei={} unallocatedWei={} projectedInsolvencyTime={} brokerCount={} isRunning={}', [
+    log.info('handleBountyUpdated: totalStakeWei={} unallocatedWei={} brokerCount={} isRunning={}', [
         event.params.totalStakeWei.toString(),
         event.params.unallocatedWei.toString(),
-        event.params.projectedInsolvencyTime.toString(),
         event.params.brokerCount.toString(),
         event.params.isRunning.toString()
     ])
@@ -44,7 +43,6 @@ export function handleBountyUpdated(event: BountyUpdate): void {
     let bounty = Bounty.load(bountyAddress.toHexString())
     bounty!.totalStakedWei = event.params.totalStakeWei
     bounty!.unallocatedWei = event.params.unallocatedWei
-    bounty!.projectedInsolvency = event.params.projectedInsolvencyTime
     bounty!.brokerCount = event.params.brokerCount.toI32()
     bounty!.isRunning = event.params.isRunning
     bounty!.save()
@@ -74,8 +72,6 @@ export function handleBountyUpdated(event: BountyUpdate): void {
         stat.unallocatedWei = stat.unallocatedWei.plus(event.params.unallocatedWei)
         // stat.totalPayoutsCumulative = stat.totalPayoutsCumulative.plus(event.params.totalPayoutsCumulative)
     }
-    stat.brokerCount = event.params.brokerCount.toI32()
-    stat.projectedInsolvency = event.params.projectedInsolvencyTime
     stat.brokerCount = event.params.brokerCount.toI32()
     stat.save()
 }

--- a/packages/network-subgraphs/subgraph.yaml
+++ b/packages/network-subgraphs/subgraph.yaml
@@ -227,7 +227,7 @@ templates:
       eventHandlers:
           - event: StakeUpdate(indexed address,uint256,uint256)
             handler: handleStakeUpdated
-          - event: BountyUpdate(uint256,uint256,uint256,uint32,bool)
+          - event: BountyUpdate(uint256,uint256,uint32,bool)
             handler: handleBountyUpdated
           - event: FlagUpdate(indexed address,address,uint256,uint256)
             handler: handleFlagUpdate


### PR DESCRIPTION
refactor: Bounty events change: BrokerKicked/Slashed separated (all slashings now in BrokerSlashed), avoid solventUntil call in every BountyUpdate