### PR TITLE
feat: Controller role in Operator contract

### DIFF
--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
@@ -13,11 +13,11 @@ import { setupSponsorships } from "./setupSponsorships"
 const { parseEther, formatEther, hexZeroPad } = utils
 const { getSigners, getContractFactory } = hardhatEthers
 
-describe("Operator", (): void => {
-    let admin: Wallet       // creates the Sponsorship
-    let sponsor: Wallet     // sponsors the Sponsorship
-    let operatorWallet: Wallet    // creates Operator contract
-    let delegator: Wallet   // puts DATA into Operator contract
+describe("Operator contract", (): void => {
+    let admin: Wallet           // creates the Sponsorship
+    let sponsor: Wallet         // sponsors the Sponsorship
+    let operatorWallet: Wallet  // creates Operator contract
+    let delegator: Wallet       // puts DATA into Operator contract
     let delegator2: Wallet
     let delegator3: Wallet
 

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
@@ -901,10 +901,4 @@ describe("Operator", (): void => {
             await expect(operator.connect(delegator2).heartbeat("{}")).to.emit(operator, "Heartbeat").withArgs(delegator2.address, "{}")
         })
     })
-
-    it("negativeTest: operator signer cannot deploy operator twice", async function(): Promise<void> {
-        await deployOperator(sharedContracts, operatorWallet)
-        await expect(deployOperator(sharedContracts, operatorWallet))
-            .to.be.revertedWith("error_operatorAlreadyDeployed")
-    })
 })

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/OperatorFactory.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/OperatorFactory.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai"
 import { ethers as hardhatEthers } from "hardhat"
 
 import { deployTestContracts, TestContracts } from "./deployTestContracts"
-import { deployOperator } from "./deployOperatorContract"
+import { deployOperatorContract } from "./deployOperatorContract"
 import { Wallet } from "ethers"
 
 const { getSigners } = hardhatEthers
@@ -20,8 +20,8 @@ describe("OperatorFactory", function(): void {
     })
 
     it("does NOT allow same operator signer deploy a second Operator contract", async function(): Promise<void> {
-        await deployOperator(sharedContracts, operatorWallet)
-        await expect(deployOperator(sharedContracts, operatorWallet))
+        await deployOperatorContract(sharedContracts, operatorWallet)
+        await expect(deployOperatorContract(sharedContracts, operatorWallet))
             .to.be.revertedWith("error_operatorAlreadyDeployed")
     })
 })

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/OperatorFactory.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/OperatorFactory.test.ts
@@ -1,0 +1,27 @@
+import { expect } from "chai"
+import { ethers as hardhatEthers } from "hardhat"
+
+import { deployTestContracts, TestContracts } from "./deployTestContracts"
+import { deployOperator } from "./deployOperatorContract"
+import { Wallet } from "ethers"
+
+const { getSigners } = hardhatEthers
+
+describe("OperatorFactory", function(): void {
+    let deployer: Wallet        // deploys all test contracts
+    let operatorWallet: Wallet  // creates Operator contract
+
+    // many tests don't need their own clean set of contracts that take time to deploy
+    let sharedContracts: TestContracts
+
+    before(async (): Promise<void> => {
+        [deployer, operatorWallet] = await getSigners() as unknown as Wallet[]
+        sharedContracts = await deployTestContracts(deployer)
+    })
+
+    it("does NOT allow same operator signer deploy a second Operator contract", async function(): Promise<void> {
+        await deployOperator(sharedContracts, operatorWallet)
+        await expect(deployOperator(sharedContracts, operatorWallet))
+            .to.be.revertedWith("error_operatorAlreadyDeployed")
+    })
+})

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Sponsorship.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Sponsorship.test.ts
@@ -16,7 +16,7 @@ import {
 
 import { deploySponsorshipWithoutFactory } from "./deploySponsorshipContract"
 
-describe("Sponsorship", (): void => {
+describe("Sponsorship contract", (): void => {
     let admin: Wallet
     let operator: Wallet
     let operator2: Wallet

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipFactory.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipFactory.test.ts
@@ -7,7 +7,7 @@ const { getSigners } = hardhatEthers
 
 import { deployTestContracts, TestContracts } from "./deployTestContracts"
 import { deploySponsorship } from "./deploySponsorshipContract"
-import { deployOperator } from "./deployOperatorContract"
+import { deployOperatorContract } from "./deployOperatorContract"
 
 let sponsorshipCounter = 0
 
@@ -26,7 +26,7 @@ describe("SponsorshipFactory", () => {
     it("can deploy a Sponsorship; then Operator can join, increase stake (happy path)", async function(): Promise<void> {
         const { token } = contracts
         const sponsorship = await deploySponsorship(contracts)
-        const pool = await deployOperator(contracts, admin)
+        const pool = await deployOperatorContract(contracts, admin)
         await (await token.mint(pool.address, parseEther("200"))).wait()
         await expect(pool.stake(sponsorship.address, parseEther("200")))
             .to.emit(sponsorship, "OperatorJoined").withArgs(pool.address)

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/OperatorContractOnlyJoinPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/OperatorContractOnlyJoinPolicy.test.ts
@@ -9,7 +9,7 @@ import {
     deployTestContracts,
     TestContracts,
 } from "../deployTestContracts"
-import { deployOperator } from "../deployOperatorContract"
+import { deployOperatorContract } from "../deployOperatorContract"
 import { deploySponsorship } from "../deploySponsorshipContract"
 
 describe("OperatorContractOnlyJoinPolicy", (): void => {
@@ -40,7 +40,7 @@ describe("OperatorContractOnlyJoinPolicy", (): void => {
         await expect(badOp.stake(sponsorship.address, parseEther("100")))
             .to.be.revertedWith("error_onlyOperators")
 
-        const goodOp = await deployOperator(contracts, operator)
+        const goodOp = await deployOperatorContract(contracts, operator)
         await (await token.transferAndCall(goodOp.address, parseEther("100"), "0x")).wait()
         await expect(goodOp.stake(sponsorship.address, parseEther("100")))
             .to.emit(sponsorship, "OperatorJoined").withArgs(goodOp.address)

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/deployOperatorContract.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/deployOperatorContract.ts
@@ -8,7 +8,7 @@ let poolindex = 0
  * @param deployer should be the operator's Wallet
  * @returns Operator
  */
-export async function deployOperator(contracts: TestContracts, deployer: Wallet, {
+export async function deployOperatorContract(contracts: TestContracts, deployer: Wallet, {
     maintenanceMarginPercent = 0,
     maxOperatorDivertPercent = 0,
     minOperatorStakePercent = 0,

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/setupSponsorships.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/setupSponsorships.ts
@@ -3,7 +3,7 @@ import { BigNumber, utils, Wallet } from "ethers"
 
 import { deployOperatorFactory, TestContracts } from "./deployTestContracts"
 import { deploySponsorship } from "./deploySponsorshipContract"
-import { deployOperator } from "./deployOperatorContract"
+import { deployOperatorContract } from "./deployOperatorContract"
 
 import type { Sponsorship, Operator, OperatorFactory, TestToken } from "../../../typechain"
 
@@ -63,7 +63,7 @@ export async function setupSponsorships(contracts: TestContracts, operatorCounts
 
     // no risk of nonce collisions in Promise.all since each operator has their own separate nonce
     // see OperatorFactory:_deployOperator for how saltSeed is used in CREATE2
-    const operators = await Promise.all(signers.map((signer) => deployOperator(newContracts, signer, {}, saltSeed)))
+    const operators = await Promise.all(signers.map((signer) => deployOperatorContract(newContracts, signer, {}, saltSeed)))
     const operatorsPerSponsorship = splitBy(operators, operatorCounts)
 
     // add operator also as the (only) node, so that flag/vote functions Just Work


### PR DESCRIPTION
Idea is that the owner doesn't need to put their private key into a script that manages staking/unstaking/...

also a small unrelated test refactor