### PR TITLE
Small cleanup in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint-and-unit-test:
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3

--- a/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
@@ -20,7 +20,7 @@ import "./StreamrConfig.sol";
 import "./Sponsorship.sol";
 import "./SponsorshipFactory.sol";
 
-// TODO: replace interface with import
+// TODO ETH-517: replace interface with import
 interface IStreamRegistry {
     enum PermissionType { Edit, Delete, Publish, Subscribe, Grant }
 
@@ -162,9 +162,10 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
         _createOperatorStream();
     }
 
-    /** Each operator contract creates a fleet coordination stream upon creation,
-      * id = <operatorContractAddress>/operator/coordination
-      */
+    /**
+     * Each operator contract creates a fleet coordination stream upon creation,
+     *   id = <operatorContractAddress>/operator/coordination
+     */
     function _createOperatorStream() private {
         streamRegistry = IStreamRegistry(streamrConfig.streamRegistryAddress());
         // TODO: avoid this stream.concat once streamRegistry.createStream returns the streamId (ETH-505)

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorFactory.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorFactory.sol
@@ -32,7 +32,7 @@ contract OperatorFactory is Initializable, UUPSUpgradeable, ERC2771ContextUpgrad
     Operator[] public liveOperators;
     mapping (Operator => uint) public liveOperatorsIndex; // real index +1, zero for Operators not staked in a Sponsorship
 
-    mapping (address => address) public operators; // operator wallet => contract address
+    mapping (address => address) public operators; // operator wallet => Operator contract address
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() ERC2771ContextUpgradeable(address(0x0)) {}

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorFactory.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorFactory.sol
@@ -32,7 +32,7 @@ contract OperatorFactory is Initializable, UUPSUpgradeable, ERC2771ContextUpgrad
     Operator[] public liveOperators;
     mapping (Operator => uint) public liveOperatorsIndex; // real index +1, zero for Operators not staked in a Sponsorship
 
-    mapping (address => address) public operators;
+    mapping (address => address) public operators; // operator wallet => contract address
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() ERC2771ContextUpgradeable(address(0x0)) {}
@@ -148,7 +148,7 @@ contract OperatorFactory is Initializable, UUPSUpgradeable, ERC2771ContextUpgrad
 
         require(operators[operatorAddress] == address(0), "error_operatorAlreadyDeployed");
         operators[operatorAddress] = newContractAddress;
-        
+
         return newContractAddress;
     }
 

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/OperatorContractOnlyJoinPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/OperatorContractOnlyJoinPolicy.test.ts
@@ -28,7 +28,7 @@ describe("OperatorContractOnlyJoinPolicy", (): void => {
 
     it("only allows Operators to stake", async function(): Promise<void> {
         const { streamrConfig, token } = contracts
-        const sponsorship = await deploySponsorship(contracts, { operatorOnly: true })
+        const sponsorship = await deploySponsorship(contracts)
 
         await (await token.approve(sponsorship.address, parseEther("100"))).wait()
         await expect(sponsorship.stake(operator.address, parseEther("100")))

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/deployOperatorContract.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/deployOperatorContract.ts
@@ -19,13 +19,11 @@ export async function deployOperatorContract(contracts: TestContracts, deployer:
         operatorFactory, operatorTemplate,
         defaultDelegationPolicy, defaultPoolYieldPolicy, defaultUndelegationPolicy
     } = contracts
-    // TODO: figure out if initialMargin is needed twice...
-    const initialMargin = "0"
     const poolTokenName = salt ?? `Pool-${Date.now()}-${poolindex++}`
 
     /**
-     * policies, // [0] delegation, [1] yield, [2] undelegation policy
-     * [0] initialMargin, [1] minimumMarginFraction, [2] yieldPolicyParam, [3] undelegationPolicyParam,
+     * policies: [0] delegation, [1] yield, [2] undelegation policy
+     * uint params: [0] initialMargin, [1] minimumMarginFraction, [2] yieldPolicyParam, [3] undelegationPolicyParam,
      *      [4] initialMinimumDelegationWei, [5] operatorsShareFraction
      */
     const operatorReceipt = await (await operatorFactory.connect(deployer).deployOperator(
@@ -34,9 +32,8 @@ export async function deployOperatorContract(contracts: TestContracts, deployer:
             defaultDelegationPolicy.address,
             defaultPoolYieldPolicy.address,
             defaultUndelegationPolicy.address
-        ],
-        [
-            initialMargin,
+        ], [
+            0,
             parseEther("1").mul(minOperatorStakePercent).div(100),
             0,
             0,

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/deploySponsorshipContract.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/deploySponsorshipContract.ts
@@ -31,8 +31,7 @@ export async function deploySponsorship(
     overrideKickPolicyParam?: string,
 ): Promise<Sponsorship> {
     const {
-        maxOperatorsJoinPolicy, operatorContractOnlyJoinPolicy,
-        allocationPolicy, leavePolicy, voteKickPolicy,
+        maxOperatorsJoinPolicy, allocationPolicy, leavePolicy, voteKickPolicy,
         sponsorshipTemplate, sponsorshipFactory
     } = contracts
 

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/deploySponsorshipContract.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/deploySponsorshipContract.ts
@@ -22,7 +22,6 @@ export async function deploySponsorship(
         penaltyPeriodSeconds = -1,
         maxOperatorCount = -1,
         allocationWeiPerSecond = parseEther("1"),
-        operatorOnly = false,
     } = {},
     extraJoinPolicies?: IJoinPolicy[],
     extraJoinPolicyParams?: string[],
@@ -56,10 +55,6 @@ export async function deploySponsorship(
     if (maxOperatorCount > -1) {
         policyAddresses.push(maxOperatorsJoinPolicy.address)
         policyParams.push(maxOperatorCount.toString())
-    }
-    if (operatorOnly) {
-        policyAddresses.push(operatorContractOnlyJoinPolicy.address)
-        policyParams.push("0")
     }
     if (extraJoinPolicies) {
         assert(extraJoinPolicyParams, "must give extraJoinPolicyParams if giving extraJoinPolicies")

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/setupSponsorships.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/setupSponsorships.ts
@@ -80,7 +80,6 @@ export async function setupSponsorships(contracts: TestContracts, operatorCounts
         const sponsorship = await deploySponsorship(contracts, {
             allocationWeiPerSecond: BigNumber.from(0),
             penaltyPeriodSeconds: 0,
-            operatorOnly: true,
             ...sponsorshipSettings
         })
         if (sponsor) {

--- a/packages/network-subgraphs/src/operator.ts
+++ b/packages/network-subgraphs/src/operator.ts
@@ -5,8 +5,9 @@ import { Delegated, MetadataUpdated, StakeUpdate, Undelegated } from '../generat
 import { getBucketStartDate } from './helpers'
 
 export function handleDelegationReceived (event: Delegated): void {
-    log.info('handleDelegationReceived: operatoraddress={} blockNumber={}', [event.address.toHexString(), event.block.number.toString()])
-    log.info('handleDelegationReceived: amountWei={} approxPoolValue={}', [event.params.amountWei.toString(), event.params.approxPoolValue.toString()])
+    log.info('handleDelegationReceived: operatoraddress={} blockNumber={} amountWei={} approxPoolValue={}', [
+        event.address.toHexString(), event.block.number.toString(), event.params.amountWei.toString(), event.params.approxPoolValue.toString()
+    ])
     let operator = Operator.load(event.address.toHexString())
     operator!.delegatorCount = operator!.delegatorCount + 1
     operator!.approximatePoolValue = event.params.approxPoolValue


### PR DESCRIPTION
nowadays you can't create Sponsorships without operatorContractsOnly, so removing that option