### PR TITLE
ETH-520: delete Operator.totalQueuedPerDelegatorWei

### DIFF
--- a/packages/network-contracts/test/hardhat-slow-tests/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat-slow-tests/Operator.test.ts
@@ -50,7 +50,6 @@ describe("Operator", (): void => {
         for (let i = 0; i < 1000; i++) {
             await operator.connect(delegator).undelegate(parseEther("1"))
         }
-        expect(await operator.totalQueuedPerDelegatorWei(delegator.address)).to.equal(parseEther("1000"))
 
         // doing it in one go with 1000 slots in the queue will fail...
         await advanceToTimestamp(timeAtStart + 100000, "Start paying out the queue by unstaking from sponsorship")
@@ -87,7 +86,6 @@ describe("Operator", (): void => {
             sponsorships.push(sponsorship)
         }
         await operator.connect(delegator).undelegate(totalStaked)
-        expect(await operator.totalQueuedPerDelegatorWei(delegator.address)).to.equal(totalStaked)
         expect(await operator.balanceOf(delegator.address)).to.equal(parseEther((numberOfSponsorships * 100).toString()))
 
         await advanceToTimestamp(timeAtStart + 100000, "Start paying out the queue by unstaking from sponsorship")


### PR DESCRIPTION
only useful for tests (not disputing that!), possibly wrong in general. Better to remove and track the total queued in subgraph.

Example when it's wrong:
* queue whole balance
* transfer half balance away
* total queued still is total balance
* smart contract doesn't need this accounting: it will pay out whatever the balance is (or what was requested, which ever is smaller) when the queueing is done