### PR TITLE
build: add dependency review to PRs

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,16 @@
+---
+name: Dependency
+on:
+  - pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v2


### PR DESCRIPTION
`fail-on-severity: low` could be potentially annoying, but I guess we'll just change it if it flags trusted libraries (but if it flags outdated openzeppelin and such, maybe we should consider also updating :)