### PR TITLE
ETH-539 OperatorValueBreachWatcher reward refactor

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
@@ -389,7 +389,6 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
             uint allowedDifference = poolValueBeforeWithdraw * streamrConfig.poolValueDriftLimitFraction() / 1 ether;
             uint penaltyDataWei = operatorsShareDataWei * streamrConfig.poolValueDriftPenaltyFraction() / 1 ether;
             if (sumEarnings > allowedDifference) {
-                // NOTE: careful with changing state before this line, possible re-entrancy from here!
                 token.transfer(_msgSender(), penaltyDataWei);
                 operatorPaymentDataWei -= penaltyDataWei;
             }

--- a/packages/network-contracts/contracts/OperatorTokenomics/StreamrConfig.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/StreamrConfig.sol
@@ -137,7 +137,7 @@ contract StreamrConfig is Initializable, UUPSUpgradeable, AccessControlUpgradeab
 
         maxPenaltyPeriodSeconds = 30 days;
         poolValueDriftLimitFraction = 0.1 ether;
-        poolValueDriftPenaltyFraction = 0.005 ether;
+        poolValueDriftPenaltyFraction = 0.5 ether;
         flagReviewerCount = 5;
         flagReviewerRewardWei = 1 ether;
         flaggerRewardWei = 1 ether;

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
@@ -723,7 +723,7 @@ describe("Operator contract", (): void => {
             ...await deployOperatorFactory(sharedContracts, admin)
         }
         const operator1 = await deployOperatorContract(contracts, operatorWallet, { operatorSharePercent: 40 })
-        const operator2 = await deployOperatorContract(contracts, operator2Wallet, { operatorSharePercent: 40 })
+        const operator2 = await deployOperatorContract(contracts, operator2Wallet, { operatorSharePercent: 17 }) // number doesn't affect calculations
         const sponsorship1 = await deploySponsorship(contracts)
         const sponsorship2 = await deploySponsorship(contracts)
 
@@ -764,11 +764,12 @@ describe("Operator contract", (): void => {
         // total withdrawable earnings = 2000 DATA
         // operator's share = 2000 * 40% = 800 DATA
         // the rest of the earnings (1200 DATA) was added to operator1's free funds (Profit)
-        // pool value after Profit is 2000 + 1200 = 3200 DATA => exchange rate is 3200 / 2000 = 1.6 DATA / pool token
+        // operator1 pool value after Profit is 2000 + 1200 = 3200 DATA => exchange rate is 3200 / 2000 = 1.6 DATA / pool token
         // half of the operator's share went to operator2 for being a good OperatorValueBreachWatcher, so both got 400 DATA
-        // operator2's 400 DATA was added to free funds (Profit)
-        // operator1's 400 DATA was added to pool value as self-delegation (not Profit)
+        // operator1's 400 DATA was added to operator1 pool value as self-delegation (not Profit)
         //  => operatorWallet1 received 400 / 1.6 = 250 pool tokens, in addition to the 1000 pool tokens from the initial self-delegation
+        // operator2's 400 DATA was added to operator2 pool value as self-delegation, exchange rate still 1 DATA / pool token
+        //  => operatorWallet2 received 400 / 1 = 400 pool tokens, in addition to the 1000 pool tokens from the initial self-delegation
         expect(await operator1.calculatePoolValueInData()).to.equal(parseEther("3600")) // free funds + stakes + profits + operator's self-delegation
         expect(await operator1.getApproximatePoolValue()).to.equal(parseEther("3600"))  // no unwithdrawn earnings => approximate is correct
         expect(await token.balanceOf(operator1.address)).to.equal(parseEther("1600"))   // free funds including profits + operator's self-delegation
@@ -778,7 +779,8 @@ describe("Operator contract", (): void => {
         expect(await token.balanceOf(operator2.address)).to.equal(parseEther("1400"))
 
         expect(await operator1.balanceOf(delegator.address)).to.equal(parseEther("1000"))
-        expect(await operator1.balanceOf(operatorWallet.address)).to.equal(parseEther("1250")) // operator's self-delegation
+        expect(await operator1.balanceOf(operatorWallet.address)).to.equal(parseEther("1250")) // operator1's self-delegation
+        expect(await operator2.balanceOf(operator2Wallet.address)).to.equal(parseEther("1400")) // operator2's self-delegation
     })
 
     it("gets notified when kicked (IOperator interface)", async function(): Promise<void> {


### PR DESCRIPTION
for the case when OperatorValueBreachWatcher calls it

now reward is paid from the withdrawn DATA tokens, so it's not hacky like
   the previous solution (where there were no tokens to take from since only
   "approximate value" was updated, not token balances, so had to take tokens
   from where they were, i.e. pool tokens). Now that earnings are actually
   withdrawn, this simplifies the reward payment a lot as well.
   