### PR TITLE
ETH-546: replace deprecated ENS package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -250,215 +250,31 @@
       "resolved": "https://registry.npmjs.org/@ensdomains/buffer/-/buffer-0.1.1.tgz",
       "integrity": "sha512-92SfSiNS8XorgU7OUBHo/i1ZU7JV7iz/6bKuLPNVsMxV79/eI7fJR6jfJJc40zAHjs3ha+Xo965Idomlq3rqnw=="
     },
-    "node_modules/@ensdomains/dnssec-oracle": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@ensdomains/dnssec-oracle/-/dnssec-oracle-0.2.0.tgz",
-      "integrity": "sha512-dYVCNhr3DIjE8uEGQ3PXElUxl4bkfltHz0LcL5DPgiaXehjLPvi4wtbtmV0jRXb3EhSaGDYBDiHrKfJ0wG7IoA==",
-      "deprecated": "Please use @ensdomains/ens-contracts",
+    "node_modules/@ensdomains/ens-contracts": {
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@ensdomains/ens-contracts/-/ens-contracts-0.0.22.tgz",
+      "integrity": "sha512-kNu7pp68/5KfJ5wkswnUS4NfI9Ek4zGi0nnNSmGf1WXs6BHU9NYRVR6NnoVzb1B+cZ658e1v2srTtvmBYYIYzg==",
       "dependencies": {
-        "dns-packet": "^5.0.4"
-      }
-    },
-    "node_modules/@ensdomains/ens": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@ensdomains/ens/-/ens-0.6.2.tgz",
-      "integrity": "sha512-F3ALgp60HZq3rKqNig7H/rAlBB0zuz4C9q2weCoiPjSW91uvjetXhCGBU2YJCD1tyuKnO/KqTDzUN5Dc8HLlaQ==",
-      "deprecated": "Please use @ensdomains/ens-contracts",
-      "dependencies": {
-        "bluebird": "^3.5.2",
-        "eth-ens-namehash": "^2.0.8",
-        "solc": "^0.4.20",
-        "testrpc": "0.0.1"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/camelcase": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha512-4nhGqUkc4BqbBBB4Q6zLuD7lzzrHYrjKGeYaEji/3tFR5VdJu9v+LilhGIVe8wxEJPPOeWo7eg8dwY13TZ1BNg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/fs-extra": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-      "integrity": "sha512-UvSPKyhMn6LEd/WpUaV9C9t3zATuqoqfWc3QdPhPLb58prN9tqYPlPWi8Krxi44loBoUzlobqZ3+8tGpxxSzwA==",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rimraf": "^2.2.8"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
-    },
-    "node_modules/@ensdomains/ens/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/require-from-string": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-      "integrity": "sha512-H7AkJWMobeskkttHyhTVtS0fxpFLjxhbfMa6Bk3wimP7sdPRGL3EyCg3sAQenFfAe+xQ+oAc85Nmtvq0ROM83Q==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/solc": {
-      "version": "0.4.26",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.26.tgz",
-      "integrity": "sha512-o+c6FpkiHd+HPjmjEVpQgH7fqZ14tJpXhho+/bQXlXbliLIS/xjXb42Vxh+qQY1WCSTMQ0+a5vR9vi0MfhU6mA==",
-      "dependencies": {
-        "fs-extra": "^0.30.0",
-        "memorystream": "^0.3.1",
-        "require-from-string": "^1.1.0",
-        "semver": "^5.3.0",
-        "yargs": "^4.7.1"
-      },
-      "bin": {
-        "solcjs": "solcjs"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/y18n": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ=="
-    },
-    "node_modules/@ensdomains/ens/node_modules/yargs": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-      "integrity": "sha512-LqodLrnIDM3IFT+Hf/5sxBnEGECrfdC1uIbgZeJmESCSo4HoCAaKEus8MylXHAkdacGc0ye+Qa+dpkuom8uVYA==",
-      "dependencies": {
-        "cliui": "^3.2.0",
-        "decamelize": "^1.1.1",
-        "get-caller-file": "^1.0.1",
-        "lodash.assign": "^4.0.3",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^1.0.1",
-        "which-module": "^1.0.0",
-        "window-size": "^0.2.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^2.4.1"
-      }
-    },
-    "node_modules/@ensdomains/ens/node_modules/yargs-parser": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-      "integrity": "sha512-9pIKIJhnI5tonzG6OnCFlz/yln8xHYcGl+pn3xR0Vzff0vzN1PbNRaelgfgRUwZ3s4i3jvxT9WhmUGL4whnasA==",
-      "dependencies": {
-        "camelcase": "^3.0.0",
-        "lodash.assign": "^4.0.6"
+        "@ensdomains/buffer": "^0.1.1",
+        "@ensdomains/solsha1": "0.0.3",
+        "@openzeppelin/contracts": "^4.1.0",
+        "dns-packet": "^5.3.0"
       }
     },
     "node_modules/@ensdomains/resolver": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@ensdomains/resolver/-/resolver-0.2.4.tgz",
       "integrity": "sha512-bvaTH34PMCbv6anRa9I/0zjLJgY4EuznbEMgbV77JBCQ9KNC46rzi0avuxpOfu+xDjPEtSFGqVEOr5GlUSGudA==",
-      "deprecated": "Please use @ensdomains/ens-contracts"
+      "deprecated": "Please use @ensdomains/ens-contracts",
+      "dev": true
+    },
+    "node_modules/@ensdomains/solsha1": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@ensdomains/solsha1/-/solsha1-0.0.3.tgz",
+      "integrity": "sha512-uhuG5LzRt/UJC0Ux83cE2rCKwSleRePoYdQVcqPN1wyf3/ekMzT/KZUF9+v7/AG5w9jlMLCQkUM50vfjr0Yu9Q==",
+      "dependencies": {
+        "hash-test-vectors": "^1.3.2"
+      }
     },
     "node_modules/@esbuild-kit/cjs-loader": {
       "version": "2.4.2",
@@ -7707,6 +7523,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9080,6 +8897,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -23049,6 +22867,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/hash-test-vectors": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/hash-test-vectors/-/hash-test-vectors-1.3.2.tgz",
+      "integrity": "sha512-PKd/fitmsrlWGh3OpKbgNLE04ZQZsvs1ZkuLoQpeIKuwx+6CYVNdW6LaPIS1QAdZvV40+skk0w4YomKnViUnvQ=="
+    },
     "node_modules/hash.js": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
@@ -23084,7 +22907,8 @@
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
     },
     "node_modules/http-basic": {
       "version": "8.1.3",
@@ -23620,6 +23444,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -23853,7 +23678,8 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
     },
     "node_modules/is-bigint": {
       "version": "1.0.4",
@@ -24268,7 +24094,8 @@
     "node_modules/is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
+      "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==",
+      "dev": true
     },
     "node_modules/is-weakref": {
       "version": "1.0.2",
@@ -24819,6 +24646,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
+      "dev": true,
       "dependencies": {
         "invert-kv": "^1.0.0"
       },
@@ -24917,6 +24745,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -24932,6 +24761,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
+      "dev": true,
       "dependencies": {
         "error-ex": "^1.2.0"
       },
@@ -24943,6 +24773,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -24970,7 +24801,8 @@
     "node_modules/lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw=="
+      "integrity": "sha512-hFuH8TY+Yji7Eja3mGiuAxBqLagejScbG8GbG0j6o9vzn0YL14My+ktnqtZgFTosKymC9/44wP6s7xyuLfnClw==",
+      "dev": true
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -26217,7 +26049,6 @@
     },
     "node_modules/node-datachannel/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -26226,13 +26057,11 @@
     },
     "node_modules/node-datachannel/node_modules/aproba": {
       "version": "1.2.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-datachannel/node_modules/base64-js": {
       "version": "1.5.1",
-      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -26252,7 +26081,6 @@
     },
     "node_modules/node-datachannel/node_modules/buffer": {
       "version": "5.7.1",
-      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -26276,13 +26104,11 @@
     },
     "node_modules/node-datachannel/node_modules/chownr": {
       "version": "1.1.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-datachannel/node_modules/code-point-at": {
       "version": "1.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -26291,19 +26117,16 @@
     },
     "node_modules/node-datachannel/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-datachannel/node_modules/core-util-is": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-datachannel/node_modules/decompress-response": {
       "version": "6.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -26318,7 +26141,6 @@
     },
     "node_modules/node-datachannel/node_modules/deep-extend": {
       "version": "0.6.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -26327,13 +26149,11 @@
     },
     "node_modules/node-datachannel/node_modules/delegates": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-datachannel/node_modules/detect-libc": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -26342,7 +26162,6 @@
     },
     "node_modules/node-datachannel/node_modules/end-of-stream": {
       "version": "1.4.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -26351,7 +26170,6 @@
     },
     "node_modules/node-datachannel/node_modules/expand-template": {
       "version": "2.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "(MIT OR WTFPL)",
       "engines": {
@@ -26360,25 +26178,21 @@
     },
     "node_modules/node-datachannel/node_modules/fs-constants": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-datachannel/node_modules/github-from-package": {
       "version": "0.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-datachannel/node_modules/has-unicode": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-datachannel/node_modules/ieee754": {
       "version": "1.2.1",
-      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -26398,19 +26212,16 @@
     },
     "node_modules/node-datachannel/node_modules/inherits": {
       "version": "2.0.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-datachannel/node_modules/ini": {
       "version": "1.3.8",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-datachannel/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -26422,13 +26233,11 @@
     },
     "node_modules/node-datachannel/node_modules/isarray": {
       "version": "1.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-datachannel/node_modules/lru-cache": {
       "version": "6.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -26440,13 +26249,11 @@
     },
     "node_modules/node-datachannel/node_modules/lru-cache/node_modules/yallist": {
       "version": "4.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-datachannel/node_modules/mimic-response": {
       "version": "3.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -26458,25 +26265,21 @@
     },
     "node_modules/node-datachannel/node_modules/minimist": {
       "version": "1.2.6",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-datachannel/node_modules/mkdirp-classic": {
       "version": "0.5.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-datachannel/node_modules/napi-build-utils": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-datachannel/node_modules/node-abi": {
       "version": "3.8.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -26488,7 +26291,6 @@
     },
     "node_modules/node-datachannel/node_modules/node-abi/node_modules/semver": {
       "version": "7.3.7",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -26503,7 +26305,6 @@
     },
     "node_modules/node-datachannel/node_modules/npmlog": {
       "version": "4.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -26515,7 +26316,6 @@
     },
     "node_modules/node-datachannel/node_modules/npmlog/node_modules/are-we-there-yet": {
       "version": "1.1.7",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -26525,7 +26325,6 @@
     },
     "node_modules/node-datachannel/node_modules/npmlog/node_modules/gauge": {
       "version": "2.7.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -26541,7 +26340,6 @@
     },
     "node_modules/node-datachannel/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -26550,7 +26348,6 @@
     },
     "node_modules/node-datachannel/node_modules/object-assign": {
       "version": "4.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -26559,7 +26356,6 @@
     },
     "node_modules/node-datachannel/node_modules/once": {
       "version": "1.4.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -26568,7 +26364,6 @@
     },
     "node_modules/node-datachannel/node_modules/prebuild-install": {
       "version": "7.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -26595,13 +26390,11 @@
     },
     "node_modules/node-datachannel/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-datachannel/node_modules/pump": {
       "version": "3.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -26611,7 +26404,6 @@
     },
     "node_modules/node-datachannel/node_modules/rc": {
       "version": "1.2.8",
-      "extraneous": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
@@ -26626,7 +26418,6 @@
     },
     "node_modules/node-datachannel/node_modules/readable-stream": {
       "version": "2.3.7",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -26641,25 +26432,21 @@
     },
     "node_modules/node-datachannel/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-datachannel/node_modules/set-blocking": {
       "version": "2.0.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-datachannel/node_modules/signal-exit": {
       "version": "3.0.3",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/node-datachannel/node_modules/simple-concat": {
       "version": "1.0.1",
-      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -26679,7 +26466,6 @@
     },
     "node_modules/node-datachannel/node_modules/simple-get": {
       "version": "4.0.1",
-      "extraneous": true,
       "funding": [
         {
           "type": "github",
@@ -26704,7 +26490,6 @@
     },
     "node_modules/node-datachannel/node_modules/string_decoder": {
       "version": "1.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -26713,7 +26498,6 @@
     },
     "node_modules/node-datachannel/node_modules/string-width": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -26727,7 +26511,6 @@
     },
     "node_modules/node-datachannel/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -26739,7 +26522,6 @@
     },
     "node_modules/node-datachannel/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -26748,7 +26530,6 @@
     },
     "node_modules/node-datachannel/node_modules/tar-fs": {
       "version": "2.1.1",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -26760,7 +26541,6 @@
     },
     "node_modules/node-datachannel/node_modules/tar-stream": {
       "version": "2.1.4",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -26776,7 +26556,6 @@
     },
     "node_modules/node-datachannel/node_modules/tar-stream/node_modules/bl": {
       "version": "4.1.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -26787,7 +26566,6 @@
     },
     "node_modules/node-datachannel/node_modules/tar-stream/node_modules/readable-stream": {
       "version": "3.6.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -26801,7 +26579,6 @@
     },
     "node_modules/node-datachannel/node_modules/tunnel-agent": {
       "version": "0.6.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -26813,13 +26590,11 @@
     },
     "node_modules/node-datachannel/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/node-datachannel/node_modules/wide-align": {
       "version": "1.1.5",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -26828,7 +26603,6 @@
     },
     "node_modules/node-datachannel/node_modules/wrappy": {
       "version": "1.0.2",
-      "extraneous": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -27142,6 +26916,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
       "dependencies": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
@@ -27153,6 +26928,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -27207,6 +26983,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -27566,6 +27343,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
+      "dev": true,
       "dependencies": {
         "lcid": "^1.0.0"
       },
@@ -28757,6 +28535,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
+      "dev": true,
       "dependencies": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -28770,6 +28549,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
+      "dev": true,
       "dependencies": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -28782,6 +28562,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha512-jvElSjyuo4EMQGoTwo1uJU5pQMwTW5lS1x05zzfJuTIyLR3zwO27LYrxNg+dlvKpGOuGy/MzBdXh80g0ve5+HA==",
+      "dev": true,
       "dependencies": {
         "path-exists": "^2.0.0",
         "pinkie-promise": "^2.0.0"
@@ -28794,6 +28575,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
+      "dev": true,
       "dependencies": {
         "pinkie-promise": "^2.0.0"
       },
@@ -28805,6 +28587,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
@@ -28818,6 +28601,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -29077,7 +28861,8 @@
     "node_modules/require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug=="
+      "integrity": "sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.17.0",
@@ -31071,6 +30856,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -31079,12 +30865,14 @@
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -31093,7 +30881,8 @@
     "node_modules/spdx-license-ids": {
       "version": "3.0.13",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
-      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w=="
+      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
+      "dev": true
     },
     "node_modules/split": {
       "version": "1.0.1",
@@ -31733,6 +31522,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
+      "dev": true,
       "dependencies": {
         "is-utf8": "^0.2.0"
       },
@@ -32124,7 +31914,8 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/testrpc/-/testrpc-0.0.1.tgz",
       "integrity": "sha512-afH1hO+SQ/VPlmaLUFj2636QMeDvPCeQMc/9RBMW0IfjNe9gFD9Ra3ShqYkB7py0do1ZcCna/9acHyzTJ+GcNA==",
-      "deprecated": "testrpc has been renamed to ganache-cli, please use this package from now on."
+      "deprecated": "testrpc has been renamed to ganache-cli, please use this package from now on.",
+      "dev": true
     },
     "node_modules/text-hex": {
       "version": "1.0.0",
@@ -32937,6 +32728,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
@@ -34242,7 +34034,8 @@
     "node_modules/which-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ=="
+      "integrity": "sha512-F6+WgncZi/mJDrammbTuHe1q0R5hOXv/mBaiNA2TCNT/LTHusX0V+CJnj9XT8ki5ln2UZyyddDgHfCzyrOH7MQ==",
+      "dev": true
     },
     "node_modules/which-pm-runs": {
       "version": "1.1.0",
@@ -34299,6 +34092,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
       "integrity": "sha512-UD7d8HFA2+PZsbKyaOCEy8gMh1oDtHgJh1LfgjQ4zVXmYjAT/kvz3PueITKuqDiIXQe7yzpPnxX3lNc+AhQMyw==",
+      "dev": true,
       "bin": {
         "window-size": "cli.js"
       },
@@ -34613,8 +34407,6 @@
         "@openzeppelin/contracts-upgradeable-4.4.2": "npm:@openzeppelin/contracts-upgradeable@4.4.2"
       },
       "devDependencies": {
-        "@ensdomains/ens": "0.6.2",
-        "@ensdomains/resolver": "0.2.4",
         "@ethersproject/bignumber": "5.5.0",
         "@ethersproject/contracts": "5.5.0",
         "@ethersproject/experimental": "5.5.0",
@@ -35550,8 +35342,6 @@
       "license": "ISC",
       "dependencies": {
         "@chainlink/contracts": "0.3.1",
-        "@ensdomains/ens": "0.6.2",
-        "@ensdomains/resolver": "0.2.4",
         "@ethersproject/bignumber": "5.7.0",
         "@ethersproject/contracts": "5.7.0",
         "@ethersproject/experimental": "5.7.0",
@@ -36460,7 +36250,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ensdomains/ens": "^0.6.2",
+        "@ensdomains/ens-contracts": "^0.0.22",
         "@ethersproject/contracts": "^5.7.0",
         "@ethersproject/providers": "^5.7.2",
         "@ethersproject/units": "^5.7.0",
@@ -37292,14 +37082,11 @@
     },
     "packages/network-contracts": {
       "name": "@streamr/network-contracts",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "ISC",
       "dependencies": {
         "@chainlink/contracts": "0.3.1",
-        "@ensdomains/buffer": "0.1.1",
-        "@ensdomains/dnssec-oracle": "0.2.0",
-        "@ensdomains/ens": "0.6.2",
-        "@ensdomains/resolver": "0.2.4",
+        "@ensdomains/ens-contracts": "0.0.22",
         "@opengsn/contracts": "2.2.6",
         "@openzeppelin/contracts": "4.4.2",
         "@openzeppelin/contracts-upgradeable-4.4.2": "npm:@openzeppelin/contracts-upgradeable@4.4.2"

--- a/packages/chainlink-ens-external-adapter/index.js
+++ b/packages/chainlink-ens-external-adapter/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable promise/no-callback-in-promise */
-const ensAbi = require('@ensdomains/ens/build/contracts/ENS.json')
+const ensAbi = require('@ensdomains/ens-contracts/artifacts/contracts/registry/ENSRegistry.sol/ENSRegistry.json').abi
 const { ethers } = require('ethers')
 const namehash = require('eth-ens-namehash')
 const { Requester, Validator } = require('@chainlink/external-adapter')
@@ -20,7 +20,7 @@ const createRequest = (input, callback) => {
     const validator = new Validator(input, customParams)
     const jobRunID = validator.validated.id
 
-    const ensContract = new ethers.Contract(process.env.ENS_CONTRACT_ADDRESS, ensAbi.abi, provider)
+    const ensContract = new ethers.Contract(process.env.ENS_CONTRACT_ADDRESS, ensAbi, provider)
     const ensHashedName = namehash.hash(validator.validated.data.name)
     ensContract.owner(ensHashedName)
         .then((res) => {

--- a/packages/chainlink-ens-external-adapter/package.json
+++ b/packages/chainlink-ens-external-adapter/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@chainlink/external-adapter": "0.2.6",
-    "@ensdomains/ens": "0.6.2",
+    "@ensdomains/ens-contracts": "0.0.22",
     "body-parser": "1.19.1",
     "dotenv": "16.0.0",
     "eth-ens-namehash": "2.0.8",

--- a/packages/chat-contracts/package.json
+++ b/packages/chat-contracts/package.json
@@ -33,8 +33,6 @@
         "@openzeppelin/contracts-upgradeable-4.4.2": "npm:@openzeppelin/contracts-upgradeable@4.4.2"
     },
     "devDependencies": {
-        "@ensdomains/ens": "0.6.2",
-        "@ensdomains/resolver": "0.2.4",
         "@ethersproject/bignumber": "5.5.0",
         "@ethersproject/contracts": "5.5.0",
         "@ethersproject/experimental": "5.5.0",

--- a/packages/docker-dev-chain-init/package.json
+++ b/packages/docker-dev-chain-init/package.json
@@ -15,8 +15,6 @@
   "license": "ISC",
   "dependencies": {
     "@chainlink/contracts": "0.3.1",
-    "@ensdomains/ens": "0.6.2",
-    "@ensdomains/resolver": "0.2.4",
     "@ethersproject/bignumber": "5.7.0",
     "@ethersproject/contracts": "5.7.0",
     "@ethersproject/experimental": "5.7.0",

--- a/packages/ens-sync-script/package.json
+++ b/packages/ens-sync-script/package.json
@@ -11,7 +11,7 @@
   "author": "Streamr Network AG <contact@streamr.network>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ensdomains/ens": "^0.6.2",
+    "@ensdomains/ens-contracts": "^0.0.22",
     "@ethersproject/contracts": "^5.7.0",
     "@ethersproject/providers": "^5.7.2",
     "@ethersproject/units": "^5.7.0",

--- a/packages/ens-sync-script/src/index.ts
+++ b/packages/ens-sync-script/src/index.ts
@@ -6,11 +6,13 @@ import { Wallet } from "@ethersproject/wallet"
 import { Chains } from "@streamr/config"
 import { createRequire } from "module"
 import fetch from "node-fetch"
+
+// TODO: use import?
 const require = createRequire(import.meta.url)
-const ABIenscache = require("../../network-contracts/artifacts/contracts/chainlinkClient/ENSCacheV2Streamr.sol/ENSCacheV2Streamr.json")
-const ABIstreamRegistry = require("../../network-contracts/artifacts/contracts/StreamRegistry/StreamRegistryV4.sol/StreamRegistryV4.json")
+const streamRegistryAbi = require("../../network-contracts/artifacts/contracts/StreamRegistry/StreamRegistryV4.sol/StreamRegistryV4.json").abi
 const namehash = require('eth-ens-namehash')
-const ensAbi = require('@ensdomains/ens/build/contracts/ENS.json')
+const ensCacheAbi = require("../../network-contracts/artifacts/contracts/chainlinkClient/ENSCacheV2Streamr.sol/ENSCacheV2Streamr.json").abi
+const ensAbi = require('@ensdomains/ens-contracts/artifacts/contracts/registry/ENSRegistry.sol/ENSRegistry.json').abi
 
 const {
     DELAY = "",
@@ -35,8 +37,8 @@ let sidechainProvider: Provider
 let mutex = Promise.resolve(true)
 let domainOwnerSidechain: Wallet
 
-async function main(){
-    
+async function main() {
+
     if (delay) {
         log(`starting with answer delay ${delay} milliseconds`)
     }
@@ -57,14 +59,14 @@ async function main(){
         privateKey = "0x5e98cce00cff5dea6b454889f359a4ec06b9fa6b88e9d69b86de8e1c81887da0"
         ENSCacheV2Address = sidechainConfig.contracts.ENSCacheV2
     }
-    
+
     const ensAddress = mainnetConfig.contracts.ENS
 
-    streamRegistryContract = new Contract(sidechainConfig.contracts.StreamRegistry, ABIstreamRegistry.abi, sidechainProvider)
+    streamRegistryContract = new Contract(sidechainConfig.contracts.StreamRegistry, streamRegistryAbi, sidechainProvider)
     domainOwnerSidechain = new Wallet(privateKey, sidechainProvider)
     log("wallet address: ", domainOwnerSidechain.address)
-    ensCacheContract = new Contract(ENSCacheV2Address, ABIenscache.abi, domainOwnerSidechain) // TODO
-    ensContract = new Contract(ensAddress, ensAbi.abi, mainnetProvider)
+    ensCacheContract = new Contract(ENSCacheV2Address, ensCacheAbi, domainOwnerSidechain) // TODO
+    ensContract = new Contract(ensAddress, ensAbi, mainnetProvider)
     log("starting listening for events on ENSCacheV2 contract: ", ensCacheContract.address)
     ensCacheContract.on("RequestENSOwnerAndCreateStream", async (ensName, streamIdPath, metadataJsonString, requestorAddress) => {
         log("Got RequestENSOwnerAndCreateStream event params: ", ensName, streamIdPath, metadataJsonString, requestorAddress)

--- a/packages/network-contracts/package.json
+++ b/packages/network-contracts/package.json
@@ -40,10 +40,7 @@
   },
   "dependencies": {
     "@chainlink/contracts": "0.3.1",
-    "@ensdomains/buffer": "0.1.1",
-    "@ensdomains/dnssec-oracle": "0.2.0",
-    "@ensdomains/ens": "0.6.2",
-    "@ensdomains/resolver": "0.2.4",
+    "@ensdomains/ens-contracts": "0.0.22",
     "@opengsn/contracts": "2.2.6",
     "@openzeppelin/contracts": "4.4.2",
     "@openzeppelin/contracts-upgradeable-4.4.2": "npm:@openzeppelin/contracts-upgradeable@4.4.2"

--- a/packages/network-contracts/scripts/deployToLivenet/2_interactWithContracts.ts
+++ b/packages/network-contracts/scripts/deployToLivenet/2_interactWithContracts.ts
@@ -7,8 +7,8 @@ import { Contract, providers, Wallet, utils } from "ethers"
 import { ENSCache, Oracle, StreamRegistry } from "../../typechain"
 
 // const { ethers } = hhat
-// import ensAbi from '@ensdomains/ens/build/contracts/ENS.json'
-// import fifsAbi from '@ensdomains/ens/build/contracts/FIFSRegistrar.json'
+// import { abi as ensAbi } from "@ensdomains/ens-contracts/artifacts/contracts/registry/ENSRegistry.sol/ENSRegistry.json"
+// import { abi as fifsAbi } from "@ensdomains/ens-contracts/artifacts/contracts/registry/FIFSRegistrar.sol/FIFSRegistrar.json"
 // const resolverAbi = require('@ensdomains/resolver/build/contracts/PublicResolver.json')
 
 // hardhat
@@ -93,10 +93,10 @@ const connectToAllContracts = async () => {
     registryFromUser = await registryContract.connect(walletSidechain) as StreamRegistry
     registryFromOwner = await registryContract.connect(deploymentOwner) as StreamRegistry
 
-    // const ensContract = new Contract(ENSADDRESS, ensAbi.abi, mainnetProvider)
+    // const ensContract = new Contract(ENSADDRESS, ensAbi, mainnetProvider)
     // ensFomAdmin = await ensContract.connect(walletMainnet)
 
-    // const fifsContract = new Contract(FIFSADDRESS, fifsAbi.abi, mainnetProvider)
+    // const fifsContract = new Contract(FIFSADDRESS, fifsAbi, mainnetProvider)
     // fifsFromAdmin = await fifsContract.connect(walletMainnet)
 
     // const resolverContract = new ethers.Contract(RESOLVERADDRESS, resolverAbi.abi, mainnetProvider)

--- a/packages/network-contracts/scripts/deployToLivenet/4_deployEnsCacheScript.ts
+++ b/packages/network-contracts/scripts/deployToLivenet/4_deployEnsCacheScript.ts
@@ -7,8 +7,8 @@ import { Chains } from "@streamr/config"
 
 import { StreamRegistry } from "../../typechain"
 
-import ensAbi from "@ensdomains/ens/build/contracts/ENS.json"
-import fifsAbi from "@ensdomains/ens/build/contracts/FIFSRegistrar.json"
+import { abi as ensAbi } from "@ensdomains/ens-contracts/artifacts/contracts/registry/ENSRegistry.sol/ENSRegistry.json"
+import { abi as fifsAbi } from "@ensdomains/ens-contracts/artifacts/contracts/registry/FIFSRegistrar.sol/FIFSRegistrar.json"
 
 const mainnetConfig = Chains.load()["dev0"]
 const sidechainConfig = Chains.load()["dev1"]
@@ -21,7 +21,7 @@ if (keyidparam == "0") {
     DEFAULTPRIVATEKEY = "0x5e98cce00cff5dea6b454889f359a4ec06b9fa6b88e9d69b86de8e1c81887da0" // deploymentowner of streamregistry
 } else if (keyidparam == "1") {
     DEFAULTPRIVATEKEY = "0xe5af7834455b7239881b85be89d905d6881dcb4751063897f12be1b0dd546bdb" // owner of testdomain1.eth
-} else if (keyidparam == "2") { 
+} else if (keyidparam == "2") {
     DEFAULTPRIVATEKEY = "0x4059de411f15511a85ce332e7a428f36492ab4e87c7830099dadbf130f1896ae" // owner of testdomain2.eth
 }
 // const MAINNETURL = "http://localhost:8545"
@@ -57,16 +57,16 @@ const connectToAllContracts = async () => {
     const registryContract = await registry.deployed()
     registryFromUser = await registryContract.connect(domainOwnerSidechain) as StreamRegistry
 
-    const ensContract = new Contract(ENSADDRESS, ensAbi.abi, mainnetProvider)
+    const ensContract = new Contract(ENSADDRESS, ensAbi, mainnetProvider)
     ensFromAdmin = await ensContract.connect(domainOwner)
 
-    const fifsContract = new Contract(FIFSADDRESS, fifsAbi.abi, mainnetProvider)
+    const fifsContract = new Contract(FIFSADDRESS, fifsAbi, mainnetProvider)
     fifsFromAdmin = await fifsContract.connect(domainOwner)
 }
 
 const deployEnsCacheScript = async () => {
     const ensCacheScriptFactory = await ethers.getContractFactory("ENSCacheV2Streamr", domainOwnerSidechain)
-    const ensCacheScript = await upgrades.deployProxy(ensCacheScriptFactory, 
+    const ensCacheScript = await upgrades.deployProxy(ensCacheScriptFactory,
         [domainOwner.address,
             sidechainConfig.contracts.StreamRegistry,
             ENSCacheV1], { kind: "uups" })

--- a/packages/network-contracts/scripts/deployToLivenet/4a_prod_deployEnsCacheScript.ts
+++ b/packages/network-contracts/scripts/deployToLivenet/4a_prod_deployEnsCacheScript.ts
@@ -7,8 +7,8 @@ import { Chains } from "@streamr/config"
 
 import { StreamRegistry } from "../../typechain"
 
-import ensAbi from "@ensdomains/ens/build/contracts/ENS.json"
-import fifsAbi from "@ensdomains/ens/build/contracts/FIFSRegistrar.json"
+import { abi as ensAbi } from "@ensdomains/ens-contracts/artifacts/contracts/registry/ENSRegistry.sol/ENSRegistry.json"
+import { abi as fifsAbi } from "@ensdomains/ens-contracts/artifacts/contracts/registry/FIFSRegistrar.sol/FIFSRegistrar.json"
 
 // const mainnetConfig = Chains.load()["polygon"]
 const sidechainConfig = Chains.load()["polygon"]
@@ -21,7 +21,7 @@ const DEFAULTPRIVATEKEY = process.env.PRIVATE_KEY || ""
 //     DEFAULTPRIVATEKEY = "0x5e98cce00cff5dea6b454889f359a4ec06b9fa6b88e9d69b86de8e1c81887da0" // deploymentowner of streamregistry
 // } else if (keyidparam == "1") {
 //     DEFAULTPRIVATEKEY = "0xe5af7834455b7239881b85be89d905d6881dcb4751063897f12be1b0dd546bdb" // owner of testdomain1.eth
-// } else if (keyidparam == "2") { 
+// } else if (keyidparam == "2") {
 //     DEFAULTPRIVATEKEY = "0x4059de411f15511a85ce332e7a428f36492ab4e87c7830099dadbf130f1896ae" // owner of testdomain2.eth
 // }
 
@@ -58,16 +58,16 @@ const connectToAllContracts = async () => {
     const registryContract = await registry.deployed()
     registryFromUser = await registryContract.connect(domainOwnerSidechain) as StreamRegistry
 
-    // const ensContract = new Contract(ENSADDRESS, ensAbi.abi, mainnetProvider)
+    // const ensContract = new Contract(ENSADDRESS, ensAbi, mainnetProvider)
     // ensFromAdmin = await ensContract.connect(domainOwner)
 
-    // const fifsContract = new Contract(FIFSADDRESS, fifsAbi.abi, mainnetProvider)
+    // const fifsContract = new Contract(FIFSADDRESS, fifsAbi, mainnetProvider)
     // fifsFromAdmin = await fifsContract.connect(domainOwner)
 }
 
 const deployEnsCacheScript = async () => {
     const ensCacheScriptFactory = await ethers.getContractFactory("ENSCacheV2Streamr", domainOwnerSidechain)
-    const ensCacheScript = await upgrades.deployProxy(ensCacheScriptFactory, 
+    const ensCacheScript = await upgrades.deployProxy(ensCacheScriptFactory,
         ["0xc244dA783A3B96f4D420A4eEfb105CD0Db4bE01a",
             sidechainConfig.contracts.StreamRegistry,
             ENSCacheV1], { kind: "uups" })

--- a/packages/network-contracts/src/exports.ts
+++ b/packages/network-contracts/src/exports.ts
@@ -66,11 +66,14 @@ export type { DefaultUndelegationPolicy } from "../typechain/contracts/OperatorT
 
 export { abi as operatorContractOnlyJoinPolicy, bytecode as operatorContractOnlyJoinPolicyBytecode }
     from "../artifacts/contracts/OperatorTokenomics/SponsorshipPolicies/OperatorContractOnlyJoinPolicy.sol/OperatorContractOnlyJoinPolicy.json"
-export type { OperatorContractOnlyJoinPolicy } from
-    "../typechain/contracts/OperatorTokenomics/SponsorshipPolicies/OperatorContractOnlyJoinPolicy.sol/OperatorContractOnlyJoinPolicy"
+export type { OperatorContractOnlyJoinPolicy }
+    from "../typechain/contracts/OperatorTokenomics/SponsorshipPolicies/OperatorContractOnlyJoinPolicy.sol/OperatorContractOnlyJoinPolicy"
 
-export { abi as ensRegistryAbi, bytecode as ensRegistryBytecode } from "@ensdomains/ens/build/contracts/ENSRegistry.json"
-export { abi as fifsRegistrarAbi, bytecode as fifsRegistrarBytecode } from "@ensdomains/ens/build/contracts/FIFSRegistrar.json"
-export { abi as publicResolverAbi, bytecode as publicResolverBytecode } from "@ensdomains/resolver/build/contracts/PublicResolver.json"
+export { abi as ensRegistryAbi, bytecode as ensRegistryBytecode }
+    from "@ensdomains/ens-contracts/artifacts/contracts/registry/ENSRegistry.sol/ENSRegistry.json"
+export { abi as fifsRegistrarAbi, bytecode as fifsRegistrarBytecode }
+    from "@ensdomains/ens-contracts/artifacts/contracts/registry/FIFSRegistrar.sol/FIFSRegistrar.json"
+export { abi as publicResolverAbi, bytecode as publicResolverBytecode }
+    from "@ensdomains/ens-contracts/artifacts/contracts/resolvers/PublicResolver.sol/PublicResolver.json"
 
 export * from "./StreamrEnvDeployer"

--- a/packages/network-contracts/test/integration/ens-e2e.test.ts
+++ b/packages/network-contracts/test/integration/ens-e2e.test.ts
@@ -7,8 +7,8 @@ import { Chains } from "@streamr/config"
 
 import { StreamRegistry } from "../../typechain"
 
-import ensAbi from "@ensdomains/ens/build/contracts/ENS.json"
-import fifsAbi from "@ensdomains/ens/build/contracts/FIFSRegistrar.json"
+import { abi as ensAbi } from "@ensdomains/ens-contracts/artifacts/contracts/registry/ENSRegistry.sol/ENSRegistry.json"
+import { abi as fifsAbi } from "@ensdomains/ens-contracts/artifacts/contracts/registry/FIFSRegistrar.sol/FIFSRegistrar.json"
 
 const mainnetConfig = Chains.load()["dev0"]
 const sidechainConfig = Chains.load()["dev1"]
@@ -21,7 +21,7 @@ if (keyidparam == "0") {
     DEFAULTPRIVATEKEY = "0x5e98cce00cff5dea6b454889f359a4ec06b9fa6b88e9d69b86de8e1c81887da0" // deploymentowner of streamregistry
 } else if (keyidparam == "1") {
     DEFAULTPRIVATEKEY = "0xe5af7834455b7239881b85be89d905d6881dcb4751063897f12be1b0dd546bdb" // owner of testdomain1.eth
-} else if (keyidparam == "2") { 
+} else if (keyidparam == "2") {
     DEFAULTPRIVATEKEY = "0x4059de411f15511a85ce332e7a428f36492ab4e87c7830099dadbf130f1896ae" // owner of testdomain2.eth
 }
 
@@ -53,10 +53,10 @@ const connectToAllContracts = async () => {
     const registryContract = await registry.deployed()
     registryFromUser = await registryContract.connect(domainOwnerSidechain) as StreamRegistry
 
-    const ensContract = new Contract(ENSADDRESS, ensAbi.abi, mainnetProvider)
+    const ensContract = new Contract(ENSADDRESS, ensAbi, mainnetProvider)
     ensFromAdmin = await ensContract.connect(domainOwner)
 
-    const fifsContract = new Contract(FIFSADDRESS, fifsAbi.abi, mainnetProvider)
+    const fifsContract = new Contract(FIFSADDRESS, fifsAbi, mainnetProvider)
     fifsFromAdmin = await fifsContract.connect(domainOwner)
 }
 


### PR DESCRIPTION
https://www.npmjs.com/package/@ensdomains/ens is deprecated, replace with https://www.npmjs.com/package/@ensdomains/ens-contracts

Practical benefit: old package draws a LOT of dependencies like testrpc, new one is a bit more parsimonious with those. So packages like broker won't get that load of crap in their node_modules.