### PR TITLE
ETH-579: Check Operator contract function guards

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
@@ -182,7 +182,11 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
 
     function _transfer(address from, address to, uint amount) internal override {
         // enforce minimum delegation amount, but allow transfering everything (i.e. fully undelegate)
-        require(balanceOf(from) >= amount + streamrConfig.minimumDelegationWei() || balanceOf(from) == amount, "error_delegationBelowMinimum");
+        uint minimumDelegationWei = streamrConfig.minimumDelegationWei();
+        require(balanceOf(to) + amount >= minimumDelegationWei &&
+            (balanceOf(from) >= amount + minimumDelegationWei || balanceOf(from) == amount),
+            "error_delegationBelowMinimum"
+        );
         super._transfer(from, to, amount);
         emit BalanceUpdate(from, balanceOf(from), totalSupply());
         emit BalanceUpdate(to, balanceOf(to), totalSupply());

--- a/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
@@ -660,8 +660,6 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
         return queueLastIndex - queueCurrentIndex + 1;
     }
 
-    /* solhint-disable reentrancy */ // TODO: remove when solhint stops being silly
-
     /** Pay out up to maxIterations items in the queue */
     function payOutQueueWithFreeFunds(uint maxIterations) public {
         if (maxIterations == 0) { maxIterations = 1 ether; }
@@ -730,8 +728,6 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
 
         return token.balanceOf(address(this)) == 0 || queueIsEmpty();
     }
-
-    /* solhint-enable reentrancy */
 
     /////////////////////////////////////////
     // SPONSORSHIP CALLBACKS

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
@@ -410,7 +410,7 @@ describe("Operator contract", (): void => {
             await expect(operator.updateOperatorsCutFraction(parseEther("0.2")))
                 .to.emit(operator, "MetadataUpdated").withArgs(await operator.metadata(), operatorWallet.address, parseEther("0.2"))
             await expect(operator2.connect(operatorWallet).updateOperatorsCutFraction(parseEther("0.2")))
-                .to.be.revertedWith("error_onlyOperator")
+                .to.be.revertedWith("error_accessDeniedOperatorOnly")
         })
 
         it("can NOT update the operator cut fraction if it's staked in any sponsorships", async function(): Promise<void> {
@@ -639,7 +639,7 @@ describe("Operator contract", (): void => {
             await operator.connect(delegator).undelegate(parseEther("100"))
 
             await advanceToTimestamp(timeAtStart + gracePeriod, "Force unstaking attempt")
-            await expect(operator.connect(delegator).forceUnstake(sponsorship.address, 10)).to.be.revertedWith("error_onlyOperator")
+            await expect(operator.connect(delegator).forceUnstake(sponsorship.address, 10)).to.be.revertedWith("error_accessDeniedOperatorOnly")
 
             // after gracePeriod, anyone can trigger the unstake and payout of the queue
             // earnings are 1000, minus protocol fee 5% = 50 DATA => 950 DATA remains
@@ -756,7 +756,7 @@ describe("Operator contract", (): void => {
         await operator.connect(delegator2).undelegate(parseEther("100"))
 
         await advanceToTimestamp(timeAtStart + 29*days, "Delegator 1 wants to force-unstake too early")
-        await expect(operator.connect(delegator).forceUnstake(sponsorship1.address, 100)).to.be.revertedWith("error_onlyOperator")
+        await expect(operator.connect(delegator).forceUnstake(sponsorship1.address, 100)).to.be.revertedWith("error_accessDeniedOperatorOnly")
 
         await advanceToTimestamp(timeAtStart + 31*days, "Operator unstakes 5 data from sponsorship1")
         await operator.reduceStakeTo(sponsorship1.address, parseEther("150"))
@@ -927,7 +927,7 @@ describe("Operator contract", (): void => {
         const sponsorship = await deploySponsorship(sharedContracts)
         await (await sharedContracts.token.mint(operator.address, parseEther("1000"))).wait()
         await expect(operator.connect(admin).stake(sponsorship.address, parseEther("1000")))
-            .to.be.revertedWith("error_onlyOperator")
+            .to.be.revertedWith("error_accessDeniedOperatorOnly")
         await expect(operator.stake(sponsorship.address, parseEther("1000")))
             .to.emit(operator, "Staked").withArgs(sponsorship.address)
     })
@@ -1064,9 +1064,9 @@ describe("Operator contract", (): void => {
         it("can ONLY be updated by the operator", async function(): Promise<void> {
             const operator = await deployOperator(operatorWallet)
             await expect(operator.connect(admin).setNodeAddresses([admin.address]))
-                .to.be.revertedWith("error_onlyOperator")
+                .to.be.revertedWith("error_accessDeniedOperatorOnly")
             await expect(operator.connect(admin).updateNodeAddresses([], [admin.address]))
-                .to.be.revertedWith("error_onlyOperator")
+                .to.be.revertedWith("error_accessDeniedOperatorOnly")
             await expect(operator.setNodeAddresses([admin.address]))
                 .to.emit(operator, "NodesSet").withArgs([admin.address])
             await expect(operator.getNodeAddresses()).to.eventually.deep.equal([admin.address])
@@ -1118,7 +1118,7 @@ describe("Operator contract", (): void => {
             await advanceToTimestamp(start, "Flag starts")
             await (await flagger.setNodeAddresses([])).wait()
             await expect(flagger.flag(sponsorship.address, target.address))
-                .to.be.revertedWith("error_onlyNodes")
+                .to.be.revertedWith("error_accessDeniedNodesOnly")
 
             await (await flagger.setNodeAddresses([await flagger.owner()])).wait()
             await expect(flagger.flag(sponsorship.address, target.address))
@@ -1127,7 +1127,7 @@ describe("Operator contract", (): void => {
             await advanceToTimestamp(start + VOTE_START, "Voting starts")
             await (await voter.setNodeAddresses([])).wait()
             await expect(voter.voteOnFlag(sponsorship.address, target.address, VOTE_KICK))
-                .to.be.revertedWith("error_onlyNodes")
+                .to.be.revertedWith("error_accessDeniedNodesOnly")
 
             await (await voter.setNodeAddresses([await voter.owner()])).wait()
             await expect(voter.voteOnFlag(sponsorship.address, target.address, VOTE_KICK))
@@ -1136,7 +1136,7 @@ describe("Operator contract", (): void => {
 
         it("can call heartbeat", async function(): Promise<void> {
             const operator = await deployOperator(operatorWallet)
-            await expect(operator.heartbeat("{}")).to.be.rejectedWith("error_onlyNodes")
+            await expect(operator.heartbeat("{}")).to.be.rejectedWith("error_accessDeniedNodesOnly")
             await (await operator.setNodeAddresses([delegator2.address])).wait()
             await expect(operator.connect(delegator2).heartbeat("{}"))
                 .to.emit(operator, "Heartbeat").withArgs(delegator2.address, "{}")
@@ -1145,7 +1145,7 @@ describe("Operator contract", (): void => {
 
     it("allows controllers to act on behalf of the operator", async function(): Promise<void> {
         const operator = await deployOperator(operatorWallet)
-        await expect(operator.connect(controller).setNodeAddresses([controller.address])).to.be.revertedWith("error_onlyOperator")
+        await expect(operator.connect(controller).setNodeAddresses([controller.address])).to.be.revertedWith("error_accessDeniedOperatorOnly")
         await (await operator.grantRole(await operator.CONTROLLER_ROLE(), controller.address)).wait()
         await operator.connect(controller).setNodeAddresses([controller.address])
     })


### PR DESCRIPTION
Added comments about why withdrawing is not guarded (it can't harm)

Grouped functions according to caller role