### PR TITLE
refactor: rename `flagWithMetadata`

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
@@ -557,12 +557,8 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
     // NODE FUNCTIONS: HEARTBEAT, FLAGGING, AND VOTING
     ////////////////////////////////////////
 
-    function flag(Sponsorship sponsorship, address targetOperator) external onlyNodes {
-        sponsorship.flag(targetOperator);
-    }
-
-    function flagWithMetadata(Sponsorship sponsorship, address targetOperator, string memory flagMetadata) external onlyNodes {
-        sponsorship.flagWithMetadata(targetOperator, flagMetadata);
+    function flag(Sponsorship sponsorship, address targetOperator, string memory flagMetadata) external onlyNodes {
+        sponsorship.flag(targetOperator, flagMetadata);
     }
 
     function voteOnFlag(Sponsorship sponsorship, address targetOperator, bytes32 voteData) external onlyNodes {

--- a/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
@@ -363,19 +363,14 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
         }
     }
 
-    /** Start the flagging process to kick an abusive operator */
-    function flag(address target) public {
-        require(address(kickPolicy) != address(0), "error_notSupported");
-        moduleCall(address(kickPolicy), abi.encodeWithSelector(kickPolicy.onFlag.selector, target), "error_kickPolicyFailed");
-    }
-
     /**
      * Start the flagging process to kick an abusive operator and pass arbitrary metadata object along with the flag
      * The intended use for the metadata is to communicate the partition number and/or other conditions relevant to the failed inspection. The passed metadata is only used off-chain.
     */
-    function flagWithMetadata(address target, string memory metadataJsonString) external {
+    function flag(address target, string memory metadataJsonString) external {
         flagMetadataJson[target] = metadataJsonString;
-        flag(target);
+        require(address(kickPolicy) != address(0), "error_notSupported");
+        moduleCall(address(kickPolicy), abi.encodeWithSelector(kickPolicy.onFlag.selector, target), "error_kickPolicyFailed");
     }
 
     /** Peer reviewers vote on the flag */

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
@@ -866,7 +866,7 @@ describe("Operator contract", (): void => {
             .to.emit(operator, "Profit").withArgs(parseEther("950"), 0, parseEther("50"))
         expect(await operator.getApproximatePoolValue()).to.equal(parseEther("1950"))
 
-        await (await sponsorship.connect(admin).flag(operator.address)).wait() // TestKickPolicy actually slashes 10 ether without kicking
+        await (await sponsorship.connect(admin).flag(operator.address, "")).wait() // TestKickPolicy actually slashes 10 ether without kicking
         expect(await operator.getApproximatePoolValue()).to.equal(parseEther("1940"))
     })
 
@@ -886,7 +886,7 @@ describe("Operator contract", (): void => {
         const totalStakeInSponsorshipsAfterStake = await operator.totalStakedIntoSponsorshipsWei()
         const approxPoolValueAfterStake = await operator.getApproximatePoolValue()
 
-        await (await sponsorship.connect(admin).flag(operator.address)).wait() // TestKickPolicy actually slashes 10 ether without kicking
+        await (await sponsorship.connect(admin).flag(operator.address, "")).wait() // TestKickPolicy actually slashes 10 ether without kicking
         const totalStakeInSponsorshipsAfterSlashing = await operator.totalStakedIntoSponsorshipsWei()
         const approxPoolValueAfterSlashing = await operator.getApproximatePoolValue()
 
@@ -1121,11 +1121,11 @@ describe("Operator contract", (): void => {
 
             await advanceToTimestamp(start, "Flag starts")
             await (await flagger.setNodeAddresses([])).wait()
-            await expect(flagger.flag(sponsorship.address, target.address))
+            await expect(flagger.flag(sponsorship.address, target.address, ""))
                 .to.be.revertedWith("error_accessDeniedNodesOnly")
 
             await (await flagger.setNodeAddresses([await flagger.owner()])).wait()
-            await expect(flagger.flag(sponsorship.address, target.address))
+            await expect(flagger.flag(sponsorship.address, target.address, ""))
                 .to.emit(voter, "ReviewRequest").withArgs(sponsorship.address, target.address, "")
 
             await advanceToTimestamp(start + VOTE_START, "Voting starts")

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/AdminKickPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/AdminKickPolicy.test.ts
@@ -49,7 +49,7 @@ describe("AdminKickPolicy", (): void => {
         // event OperatorKicked(address indexed operator, uint slashedWei);
         const operatorCountBeforeKick = await sponsorship.operatorCount()
         await advanceToTimestamp(timeAtStart + 200, "operator 1 is kicked out")
-        expect (await sponsorship.connect(admin).flag(await operator.getAddress()))
+        expect (await sponsorship.connect(admin).flag(await operator.getAddress(), ""))
             .to.emit(sponsorship, "OperatorKicked")
             .withArgs(await operator.getAddress(), "0")
         const operatorCountAfterKick = await sponsorship.operatorCount()
@@ -70,7 +70,7 @@ describe("AdminKickPolicy", (): void => {
         await (await token.connect(operator).transferAndCall(sponsorship.address, parseEther("1000"), await operator.getAddress())).wait()
 
         const operatorCountBeforeReport = await sponsorship.operatorCount()
-        expect(sponsorship.connect(operator2).flag(await operator.getAddress()))
+        expect(sponsorship.connect(operator2).flag(await operator.getAddress(), ""))
             .to.emit(sponsorship, "OperatorKicked").withArgs(await operator.getAddress())
         const operatorCountAfterReport = await sponsorship.operatorCount()
 


### PR DESCRIPTION
Renamed the method to `flag` as all flagging needs to use that method in practice. There was already a `flag` method which didn't have metadata parameter. That method is now removed.

The inspection logic needs that there is partition information available, and we deliver that in the `metadata` field. There are currently no on-chain validations to the metadata. In that sense it is similar to e.g. `StreamRegistry#createStream` which needs the metadata for off-chain use, and validation is implemented off-chain.