### PR TITLE
Sponsorship fix: don't let _reduceStakeBy revert when over-slashing

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
@@ -496,7 +496,7 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
     }
 
     function min(uint a, uint b) internal pure returns (uint) {
-        return a > b ? a : b;
+        return a < b ? a : b;
     }
     function max(uint a, uint b) internal pure returns (uint) {
         return a > b ? a : b;

--- a/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
@@ -245,8 +245,8 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
         address operator = _msgSender();
         uint penaltyWei = getLeavePenalty(operator);
         if (penaltyWei > 0) {
-            _slash(operator, penaltyWei);
-            _addSponsorship(address(this), penaltyWei);
+            uint slashedWei = _slash(operator, penaltyWei);
+            _addSponsorship(address(this), slashedWei);
         }
         payoutWei = _removeOperator(operator); // forfeits committed stake
     }
@@ -257,8 +257,7 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
         require(targetStakeWei < stakedWei[operator], "error_cannotIncreaseStake");
         require(targetStakeWei >= minimumStakeOf(operator), "error_minimumStake");
 
-        payoutWei = stakedWei[operator] - targetStakeWei;
-        _reduceStakeBy(operator, payoutWei);
+        payoutWei = _reduceStakeBy(operator, stakedWei[operator] - targetStakeWei);
         token.transfer(operator, payoutWei);
 
         emit StakeUpdate(operator, stakedWei[operator], getEarnings(operator));
@@ -270,11 +269,11 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
      * @dev The caller MUST ensure those tokens are added to some other account, e.g. unallocatedWei, via _addSponsorship
      * @dev do not slash more than the whole stake!
      **/
-    function _slash(address operator, uint amountWei) internal {
-        _reduceStakeBy(operator, amountWei);
-        emit OperatorSlashed(operator, amountWei);
+    function _slash(address operator, uint amountWei) internal returns (uint actualSlashingWei) {
+        actualSlashingWei = _reduceStakeBy(operator, amountWei);
+        emit OperatorSlashed(operator, actualSlashingWei);
         if (operator.code.length > 0) {
-            try IOperator(operator).onSlash(amountWei) {} catch {}
+            try IOperator(operator).onSlash(actualSlashingWei) {} catch {}
         }
         emit StakeUpdate(operator, stakedWei[operator], getEarnings(operator));
     }
@@ -286,7 +285,7 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
      */
     function _kick(address operator, uint slashingWei) internal {
         if (slashingWei > 0) {
-            _reduceStakeBy(operator, slashingWei);
+            slashingWei = _reduceStakeBy(operator, slashingWei);
             emit OperatorSlashed(operator, slashingWei);
         }
         uint payoutWei = _removeOperator(operator);
@@ -299,13 +298,13 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
     /**
      * Moves tokens from an operator's stake to "free funds" (that are not in unallocatedWei!)
      * Does not actually send out tokens!
-     * @dev The caller MUST ensure those tokens are added to some other account, e.g. unallocatedWei, via _addSponsorship
+     * @dev The caller MUST ensure those tokens are added to some other account, e.g. unallocatedWei via _addSponsorship
      **/
-    function _reduceStakeBy(address operator, uint amountWei) private {
-        assert(amountWei <= stakedWei[operator]); // should never happen! _slashing must be designed to not slash more than the whole stake
-        stakedWei[operator] -= amountWei;
-        totalStakedWei -= amountWei;
-        moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onStakeChange.selector, operator, -int(amountWei)), "error_stakeChangeHandlerFailed");
+    function _reduceStakeBy(address operator, uint amountWei) private returns (uint actualReductionWei) {
+        actualReductionWei = min(amountWei, stakedWei[operator]);
+        stakedWei[operator] -= actualReductionWei;
+        totalStakedWei -= actualReductionWei;
+        moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onStakeChange.selector, operator, -int(actualReductionWei)), "error_stakeChangeHandlerFailed");
     }
 
     /**
@@ -318,8 +317,8 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
         // console.log("_removeOperator", operator);
 
         if (committedStakeWei[operator] > 0) {
-            _slash(operator, committedStakeWei[operator]);
-            committedForfeitedStakeWei += committedStakeWei[operator];
+            uint slashedWei = _slash(operator, committedStakeWei[operator]);
+            committedForfeitedStakeWei += slashedWei;
             committedStakeWei[operator] = 0;
         }
 
@@ -496,6 +495,9 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
         return hasRole(TRUSTED_FORWARDER_ROLE, forwarder);
     }
 
+    function min(uint a, uint b) internal pure returns (uint) {
+        return a > b ? a : b;
+    }
     function max(uint a, uint b) internal pure returns (uint) {
         return a > b ? a : b;
     }


### PR DESCRIPTION
instead just reduce stake to zero if trying to reduce too much

This case is extremely rare and hard to actually cause; basically if policies commit more stake than the operator has, then _removeOperator might try to _slash more than there is stake. In that case, since it's really "over-slashing" just slash all. It's the responsibility of the policies etc. to make sure there's enough tokens to cover reviewer rewards etc. whatever stake is committed towards.

On the other hand, when capping the slashing to stake, the amount of ACTUAL slashing/reduction must be communicated back, so that the caller doesn't simply assume slashing equals what was requested.