### PR TITLE
Fix 100% self-undelegation bug

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
@@ -180,7 +180,7 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
 
         token = IERC677(tokenAddress);
         streamrConfig = StreamrConfig(streamrConfigAddress);
-        
+
         nodeModule = INodeModule(modules[0]);
         queueModule = IQueueModule(modules[1]);
         stakeModule = IStakeModule(modules[2]);
@@ -297,7 +297,11 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
         emit PoolValueUpdate(totalStakedIntoSponsorshipsWei - totalSlashedInSponsorshipsWei, token.balanceOf(address(this)));
     }
 
-    /** DATA token transfer must have happened before calling this function, give back the correct amount of pool tokens */
+    /**
+     * This function must be called *AFTER* the DATA tokens have already been transferred
+     * @param delegator who receives the new operator tokens
+     * @param amountDataWei how many DATA tokens were transferred
+     **/
     function _mintPoolTokensFor(address delegator, uint amountDataWei) internal {
         // remove amountDataWei from pool value to get the "Pool Tokens before transfer" for the exchange rate calculation
         uint amountPoolToken = moduleCall(address(yieldPolicy),
@@ -313,7 +317,10 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
         emit BalanceUpdate(delegator, balanceOf(delegator), totalSupply());
     }
 
-    /** Add the request to undelegate into the undelegation queue */
+    /**
+     * Add the request to undelegate into the undelegation queue
+     * @param amountPoolTokenWei amount of operator tokens to convert back to DATA. Can be more than the balance; then all operator tokens are undelegated.
+     **/
     function undelegate(uint amountPoolTokenWei) public {
         moduleCall(address(queueModule), abi.encodeWithSelector(queueModule._undelegate.selector, amountPoolTokenWei));
     }

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/QueueModule.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/QueueModule.sol
@@ -27,6 +27,7 @@ contract QueueModule is IQueueModule, Operator {
         queueLastIndex++;
         payOutQueueWithFreeFunds(0);
     }
+
     /** Pay out up to maxIterations items in the queue */
     function _payOutQueueWithFreeFunds(uint maxIterations) public {
         if (maxIterations == 0) { maxIterations = 1 ether; }


### PR DESCRIPTION
Triggered on `operator.undelegate(infinity)`

_handleProfit => _splitEarnings because "earnings" is what comes from Sponsorship, and profit is what remains of it after protocol fee and operator's cut. So really that function splits earnings into those three things.