### PR TITLE
fix: ignore token transfer "return value"

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
@@ -347,8 +347,8 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
         emit SponsorshipUpdate(totalStakedWei, remainingWei, uint32(operatorCount), isRunning());
         emit OperatorLeft(operator, paidOutStakeWei);
 
-        // do the transferAndCall in the end of the function to avoid reentrancy (stakedWei[operator] == 0 now, so re-entry would fail with TransferError
-        if (!token.transferAndCall(operator, paidOutStakeWei, "stake")) { revert TransferError(); }
+        // do the transferAndCall in the end of the function to avoid reentrancy (stakedWei[operator] == 0 now, so re-entry would fail with OperatorNotStaked)
+        try { token.transferAndCall(operator, paidOutStakeWei, "stake") } catch {}
 
         return paidOutEarningsWei + paidOutStakeWei;
     }


### PR DESCRIPTION
especially if the operator token callback would throw, still proceed with removing the operator.