### PR TITLE
Minor size-optimization while working on ETH-614

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
@@ -331,23 +331,29 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
     // Implementations found in StakeModule.sol
     /////////////////////////////////////////
 
-    function stake(Sponsorship sponsorship, uint amountWei) external onlyOperator virtual {
+    function stake(Sponsorship sponsorship, uint amountWei) external onlyOperator {
         moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._stake.selector, sponsorship, amountWei));
     }
-    function reduceStakeTo(Sponsorship sponsorship, uint targetStakeWei) external onlyOperator virtual {
+    function reduceStakeTo(Sponsorship sponsorship, uint targetStakeWei) external onlyOperator {
         moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._reduceStakeTo.selector, sponsorship, targetStakeWei));
     }
-    function reduceStakeWithoutQueue(Sponsorship sponsorship, uint targetStakeWei) public onlyOperator virtual {
+    function reduceStakeWithoutQueue(Sponsorship sponsorship, uint targetStakeWei) public onlyOperator {
         moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._reduceStakeWithoutQueue.selector, sponsorship, targetStakeWei));
     }
-    function unstake(Sponsorship sponsorship) public onlyOperator virtual {
-        moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._unstake.selector, sponsorship));
-    }
-    function unstakeWithoutQueue(Sponsorship sponsorship) public onlyOperator virtual {
+    function unstakeWithoutQueue(Sponsorship sponsorship) public onlyOperator {
         moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._unstakeWithoutQueue.selector, sponsorship));
     }
-    function forceUnstake(Sponsorship sponsorship, uint maxQueuePayoutIterations) external virtual {
+    function forceUnstake(Sponsorship sponsorship, uint maxQueuePayoutIterations) external {
         moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._forceUnstake.selector, sponsorship, maxQueuePayoutIterations));
+    }
+
+    /**
+     * Unstake from a sponsorship
+     * Throws if some of the stake is locked to pay for flags (being flagged or flagging others)
+     **/
+    function unstake(Sponsorship sponsorship) public onlyOperator {
+        unstakeWithoutQueue(sponsorship);
+        payOutQueue(0);
     }
 
     //////////////////////////////////////////////////////////////////////////////////
@@ -370,11 +376,11 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
         emit MetadataUpdated(metadata, _msgSender(), newOperatorsCutFraction);
     }
 
-    function withdrawEarningsFromSponsorships(Sponsorship[] memory sponsorshipAddresses) public virtual {
+    function withdrawEarningsFromSponsorships(Sponsorship[] memory sponsorshipAddresses) public {
         // this is in stakeModule because it calls _handleProfit
         moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._withdrawEarningsFromSponsorships.selector, sponsorshipAddresses));
     }
-    function withdrawEarningsFromSponsorshipsWithoutQueue(Sponsorship[] memory sponsorshipAddresses) public virtual {
+    function withdrawEarningsFromSponsorshipsWithoutQueue(Sponsorship[] memory sponsorshipAddresses) public {
         // this is in stakeModule because it calls _handleProfit
         moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._withdrawEarningsFromSponsorshipsWithoutQueue.selector, sponsorshipAddresses));
     }

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/IStakeModule.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/IStakeModule.sol
@@ -8,7 +8,6 @@ interface IStakeModule {
     function _stake(Sponsorship sponsorship, uint amountWei) external;
     function _reduceStakeTo(Sponsorship sponsorship, uint targetStakeWei) external;
     function _reduceStakeWithoutQueue(Sponsorship sponsorship, uint targetStakeWei) external;
-    function _unstake(Sponsorship sponsorship) external;
     function _unstakeWithoutQueue(Sponsorship sponsorship) external;
     function _forceUnstake(Sponsorship sponsorship, uint maxQueuePayoutIterations) external;
     function _removeSponsorship(Sponsorship sponsorship, uint receivedDuringUnstakingWei) external;

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/StakeModule.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/StakeModule.sol
@@ -41,14 +41,14 @@ contract StakeModule is IStakeModule, Operator {
      * Except if you call this with targetStakeWei == 0, then it will actually call unstake
      **/
     function _reduceStakeTo(Sponsorship sponsorship, uint targetStakeWei) external onlyOperator {
-        reduceStakeWithoutQueue(sponsorship, targetStakeWei);
+        _reduceStakeWithoutQueue(sponsorship, targetStakeWei);
         payOutQueue(0);
     }
 
     /** In case the queue is very long (e.g. due to spamming), give the operator an option to free funds from Sponsorships to pay out the queue in parts */
     function _reduceStakeWithoutQueue(Sponsorship sponsorship, uint targetStakeWei) public onlyOperator {
         if (targetStakeWei == 0) {
-            unstakeWithoutQueue(sponsorship);
+            _unstakeWithoutQueue(sponsorship);
             return;
         }
         uint cashoutWei = sponsorship.reduceStakeTo(targetStakeWei);
@@ -56,16 +56,6 @@ contract StakeModule is IStakeModule, Operator {
         emit StakeUpdate(sponsorship, stakedInto[sponsorship] - slashedIn[sponsorship]);
         totalStakedIntoSponsorshipsWei -= cashoutWei;
         emit OperatorValueUpdate(totalStakedIntoSponsorshipsWei - totalSlashedInSponsorshipsWei, token.balanceOf(address(this)));
-    }
-
-
-    /**
-     * Unstake from a sponsorship
-     * Throws if some of the stake is locked to pay for flags (being flagged or flagging others)
-     **/
-    function _unstake(Sponsorship sponsorship) public onlyOperator {
-        unstakeWithoutQueue(sponsorship);
-        payOutQueue(0);
     }
 
     /** In case the queue is very long (e.g. due to spamming), give the operator an option to free funds from Sponsorships to pay out the queue in parts */


### PR DESCRIPTION
refactor: save 24 bytes by moving unstake back to main contract

turns out it costs more to moduleCall it than just add those 2 lines...

also removed "virtual" from the stubs now that we aren't overriding them (using _ in the names instead).