### PR TITLE
ETH-614: Operator's cut pays for slashing before delegators

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
@@ -85,6 +85,7 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
      */
     uint public totalStakedIntoSponsorshipsWei;
     uint public totalSlashedInSponsorshipsWei;
+    uint public unpaidSlashings; // operator's cut must pay all slashings, only then operator gets their cut again
 
     IDelegationPolicy public delegationPolicy;
     IExchangeRatePolicy public exchangeRatePolicy;
@@ -496,6 +497,7 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
         }
         slashedIn[sponsorship] += amountSlashed;
         totalSlashedInSponsorshipsWei += amountSlashed;
+        unpaidSlashings += amountSlashed;
         emit StakeUpdate(sponsorship, stakedInto[sponsorship] - slashedIn[sponsorship]);
         emit OperatorValueUpdate(totalStakedIntoSponsorshipsWei - totalSlashedInSponsorshipsWei, token.balanceOf(address(this)));
     }

--- a/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
@@ -16,7 +16,6 @@ import "./SponsorshipPolicies/IKickPolicy.sol";
 import "./SponsorshipPolicies/IAllocationPolicy.sol";
 import "./StreamrConfig.sol";
 
-
 /**
  * `Sponsorship` ("Stream Agreement") holds the sponsors' tokens and allocates them to operators
  * Those tokens are the *sponsorship* that the *sponsor* puts on servicing the stream
@@ -62,7 +61,7 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
     error MinimumStake();
     error CannotIncreaseStake();
     error OperatorNotStaked();
-    error LeavePenalty();
+    error LeavePenalty(uint penaltyWei);
     error ModuleCallError(address moduleAddress, bytes callBytes);
     error ModuleGetError(bytes callBytes);
     error ActiveFlag();
@@ -248,7 +247,8 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
      */
     function unstake() public returns (uint payoutWei) {
         address operator = _msgSender();
-        if (getLeavePenalty(operator) > 0) { revert LeavePenalty(); }
+        uint penaltyWei = getLeavePenalty(operator);
+        if (penaltyWei > 0) { revert LeavePenalty(penaltyWei); }
         if (lockedStakeWei[operator] > 0) { revert ActiveFlag(); }
         payoutWei = _removeOperator(operator);
     }


### PR DESCRIPTION
Interestingly, no tests broke when I added this feature  😬   added 2 tests too, to make it simple to see how the deduction works.

Added one new storage variable unpaidSlashings, those will be deducted from future operator's cuts.