### PR TITLE
Activate delegationPolicy and undelegationPolicy in _transfer

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
@@ -212,7 +212,7 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
             revert DelegationBelowMinimum();
         }
 
-        // create a new delegator: check if the delegation policy allows this delegation
+        // transfer creates a new delegator: check if the delegation policy allows this "delegation"
         if (balanceOf(to) == 0) {
             if (address(delegationPolicy) != address(0)) {
                 moduleCall(address(delegationPolicy), abi.encodeWithSelector(delegationPolicy.onDelegate.selector, to));

--- a/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
@@ -222,6 +222,9 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
         super._transfer(from, to, amount);
 
         // check if the undelegation policy allows this transfer
+        // zero reflects that the "undelegation" (transfer) already happened above.
+        // We can't do a correct check beforehand by passing in the amount because it would have to happen in the middle
+        //   of the transfer "after undelegation but before delegation", so we would actually have to burn then mint. But this works just as well.
         if (address(undelegationPolicy) != address(0)) {
             moduleCall(address(undelegationPolicy), abi.encodeWithSelector(undelegationPolicy.onUndelegate.selector, from, 0));
         }

--- a/packages/network-contracts/contracts/OperatorTokenomics/StreamrConfig.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/StreamrConfig.sol
@@ -161,10 +161,10 @@ contract StreamrConfig is Initializable, UUPSUpgradeable, AccessControlUpgradeab
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
         _setRoleAdmin(DEFAULT_ADMIN_ROLE, DEFAULT_ADMIN_ROLE);
 
-        slashingFraction = 0.1 ether;
+        slashingFraction = 0.1 ether; // 10% of stake is slashed if operator leaves early or gets kicked after vote
 
         // Operator's "skin in the game" = minimum share of total delegation (= Operator token supply)
-        minimumSelfDelegationFraction = 0.1 ether;
+        minimumSelfDelegationFraction = 0.1 ether; // 10% of the operator tokens must be held by the operator, or else new delegations are prevented
 
         // Prevent "sand delegations", set minimum delegation to 1 DATA
         minimumDelegationWei = 1 ether;
@@ -176,11 +176,11 @@ contract StreamrConfig is Initializable, UUPSUpgradeable, AccessControlUpgradeab
         maxQueueSeconds = 30 days;
 
         // Withdraw incentivization
-        maxAllowedEarningsFraction = 0.05 ether;
-        fishermanRewardFraction = 0.5 ether;
+        maxAllowedEarningsFraction = 0.05 ether; // 5% of valueWithoutEarnings is when fisherman can poach part of the operator's cut
+        fishermanRewardFraction = 0.5 ether; // 50% of operator's cut goes to fisherman
 
         // protocol fee
-        protocolFeeFraction = 0.05 ether;
+        protocolFeeFraction = 0.05 ether; // 5% of earnings go to protocol fee
         protocolFeeBeneficiary = _msgSender();
 
         // flagging + voting


### PR DESCRIPTION
this closes the loophole where operator can undelegate freely by transferring their self-delegation to a normal delegator and then undelegating