### PR TITLE
Clean up tokenomics contract tests' imports

### DIFF
--- a/packages/network-contracts/test/hardhat-slow-tests/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat-slow-tests/Operator.test.ts
@@ -7,10 +7,10 @@ import { deployOperatorContract } from "../hardhat/OperatorTokenomics/deployOper
 import { deploySponsorship } from "../hardhat/OperatorTokenomics/deploySponsorshipContract"
 
 import type { TestToken } from "../../typechain"
-import type { BigNumber, Wallet } from "ethers"
+import type { Wallet } from "ethers"
 
 const { parseEther, formatEther } = hardhatEthers.utils
-const { getSigners } = hardhatEthers
+const { getSigners, BigNumber } = hardhatEthers
 
 describe("Operator", (): void => {
     let admin: Wallet

--- a/packages/network-contracts/test/hardhat-slow-tests/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat-slow-tests/Operator.test.ts
@@ -1,15 +1,15 @@
 import { ethers as hardhatEthers } from "hardhat"
 import { expect } from "chai"
-import { BigNumber, utils, Wallet } from "ethers"
 
 import { advanceToTimestamp, getBlockTimestamp, log } from "../hardhat/OperatorTokenomics/utils"
 import { deployTestContracts } from "../hardhat/OperatorTokenomics/deployTestContracts"
 import { deployOperatorContract } from "../hardhat/OperatorTokenomics/deployOperatorContract"
-
 import { deploySponsorship } from "../hardhat/OperatorTokenomics/deploySponsorshipContract"
-import { TestToken } from "../../typechain"
 
-const { parseEther, formatEther } = utils
+import type { TestToken } from "../../typechain"
+import type { BigNumber, Wallet } from "ethers"
+
+const { parseEther, formatEther } = hardhatEthers.utils
 const { getSigners } = hardhatEthers
 
 describe("Operator", (): void => {

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
@@ -1,6 +1,5 @@
 import { ethers as hardhatEthers } from "hardhat"
 import { expect } from "chai"
-import { BigNumber, utils, Wallet } from "ethers"
 
 import { deployOperatorFactory, deployTestContracts, TestContracts } from "./deployTestContracts"
 import { advanceToTimestamp, getBlockTimestamp, VOTE_KICK, VOTE_START } from "./utils"
@@ -10,8 +9,13 @@ import { deploySponsorship } from "./deploySponsorshipContract"
 import { IKickPolicy, IExchangeRatePolicy } from "../../../typechain"
 import { setupSponsorships } from "./setupSponsorships"
 
-const { parseEther, formatEther, hexZeroPad } = utils
-const { getSigners, getContractFactory } = hardhatEthers
+import type { BigNumber, Wallet } from "ethers"
+
+const {
+    getSigners,
+    getContractFactory,
+    utils: { parseEther, formatEther, hexZeroPad }
+} = hardhatEthers
 
 describe("Operator contract", (): void => {
     let admin: Wallet           // creates the Sponsorship

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
@@ -590,7 +590,7 @@ describe("Operator contract", (): void => {
             const { token } = sharedContracts
 
             // "generateWalletWithGasAndTokens", fund a fresh random wallet
-            const operatorWallet = Wallet.createRandom().connect(admin.provider)
+            const operatorWallet = hardhatEthers.Wallet.createRandom().connect(admin.provider)
             admin.sendTransaction({ to: operatorWallet.address, value: parseEther("5000") }) // coverage test requires this amount of ETH
             await setTokens(operatorWallet, STAKE_AMOUNT)
 
@@ -1128,7 +1128,7 @@ describe("Operator contract", (): void => {
             await setTokens(delegator, "1000")
             await setTokens(sponsor, "1000")
 
-            const sponsorship = await deploySponsorship(sharedContracts,  { allocationWeiPerSecond: BigNumber.from("0") })
+            const sponsorship = await deploySponsorship(sharedContracts,  { allocationWeiPerSecond: parseEther("0") })
             const { operator } = await deployOperator(operatorWallet)
             const balanceBefore = await token.balanceOf(delegator.address)
             await (await token.connect(delegator).transferAndCall(operator.address, parseEther("1000"), "0x")).wait()

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
@@ -9,7 +9,7 @@ import { deploySponsorship } from "./deploySponsorshipContract"
 import { IKickPolicy, IExchangeRatePolicy } from "../../../typechain"
 import { setupSponsorships } from "./setupSponsorships"
 
-import type { BigNumber, Wallet } from "ethers"
+import type { Wallet } from "ethers"
 
 const {
     getSigners,

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/OperatorFactory.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/OperatorFactory.test.ts
@@ -3,10 +3,11 @@ import { ethers as hardhatEthers } from "hardhat"
 
 import { deployTestContracts, TestContracts } from "./deployTestContracts"
 import { deployOperatorContract } from "./deployOperatorContract"
-import { Wallet } from "ethers"
-import { defaultAbiCoder, parseEther } from "ethers/lib/utils"
+
+import type { Wallet } from "ethers"
 
 const { getSigners } = hardhatEthers
+const { defaultAbiCoder, parseEther } = hardhatEthers.utils
 
 describe("OperatorFactory", function(): void {
     let deployer: Wallet        // deploys all test contracts

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Sponsorship.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Sponsorship.test.ts
@@ -1,20 +1,15 @@
 import { ethers as hardhatEthers } from "hardhat"
 import { expect } from "chai"
-import { utils as ethersUtils, Wallet } from "ethers"
-
-import { Sponsorship, IAllocationPolicy, IJoinPolicy, TestToken, IKickPolicy } from "../../../typechain"
-
-const { defaultAbiCoder, parseEther, formatEther, hexZeroPad } = ethersUtils
-const { getSigners, getContractFactory } = hardhatEthers
 
 import { advanceToTimestamp, getBlockTimestamp } from "./utils"
-
-import {
-    deployTestContracts,
-    TestContracts,
-} from "./deployTestContracts"
-
+import { deployTestContracts, TestContracts } from "./deployTestContracts"
 import { deploySponsorshipWithoutFactory } from "./deploySponsorshipContract"
+
+import type { Sponsorship, IAllocationPolicy, IJoinPolicy, TestToken, IKickPolicy } from "../../../typechain"
+import type { Wallet } from "ethers"
+
+const { defaultAbiCoder, parseEther, formatEther, hexZeroPad } = hardhatEthers.utils
+const { getSigners, getContractFactory } = hardhatEthers
 
 describe("Sponsorship contract", (): void => {
     let admin: Wallet

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipFactory.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipFactory.test.ts
@@ -1,14 +1,17 @@
 import { ethers as hardhatEthers } from "hardhat"
 import { expect } from "chai"
-import { utils as ethersUtils, Wallet } from "ethers"
-
-const { defaultAbiCoder, parseEther } = ethersUtils
-const { getSigners } = hardhatEthers
 
 import { deployTestContracts, TestContracts } from "./deployTestContracts"
 import { deploySponsorship } from "./deploySponsorshipContract"
 import { deployOperatorContract } from "./deployOperatorContract"
 import { StreamRegistryV4 } from "../../../typechain"
+
+const {
+    getSigners,
+    utils: { defaultAbiCoder, parseEther }
+} = hardhatEthers
+
+import type { Wallet } from "ethers"
 
 let sponsorshipCounter = 0
 

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/AdminKickPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/AdminKickPolicy.test.ts
@@ -1,13 +1,14 @@
 import { expect } from "chai"
 import { ethers } from "hardhat"
-import { utils, Wallet } from "ethers"
 
 import { deployTestContracts, TestContracts } from "../deployTestContracts"
 import { advanceToTimestamp, getBlockTimestamp } from "../utils"
 
 import { deploySponsorshipWithoutFactory } from "../deploySponsorshipContract"
 
-const { parseEther, formatEther } = utils
+import type { Wallet } from "ethers"
+
+const { parseEther, formatEther } = ethers.utils
 
 describe("AdminKickPolicy", (): void => {
     let admin: Wallet

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/MaxOperatorsJoinPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/MaxOperatorsJoinPolicy.test.ts
@@ -1,16 +1,15 @@
 import { ethers as hardhatEthers } from "hardhat"
 import { expect } from "chai"
-import { utils as ethersUtils, Wallet } from "ethers"
 
-const { parseEther } = ethersUtils
-const { getSigners } = hardhatEthers
-
-import {
-    deployTestContracts,
-    TestContracts,
-} from "../deployTestContracts"
-
+import { deployTestContracts, TestContracts } from "../deployTestContracts"
 import { deploySponsorshipWithoutFactory } from "../deploySponsorshipContract"
+
+import type { Wallet } from "ethers"
+
+const {
+    getSigners,
+    utils: { parseEther }
+} = hardhatEthers
 
 describe("MaxOperatorsJoinPolicy", (): void => {
     let admin: Wallet

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/OperatorContractOnlyJoinPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/OperatorContractOnlyJoinPolicy.test.ts
@@ -1,18 +1,18 @@
 import { ethers as hardhatEthers } from "hardhat"
 import { expect } from "chai"
-import { utils as ethersUtils, Wallet } from "ethers"
 
-import { Operator } from "../../../../typechain"
-
-const { parseEther } = ethersUtils
-const { getSigners, getContractFactory } = hardhatEthers
-
-import {
-    deployTestContracts,
-    TestContracts,
-} from "../deployTestContracts"
+import { deployTestContracts, TestContracts } from "../deployTestContracts"
 import { deployOperatorContract } from "../deployOperatorContract"
 import { deploySponsorship } from "../deploySponsorshipContract"
+
+import type { Wallet } from "ethers"
+import type { Operator } from "../../../../typechain"
+
+const {
+    getSigners,
+    getContractFactory,
+    utils: { parseEther }
+} = hardhatEthers
 
 describe("OperatorContractOnlyJoinPolicy", (): void => {
     let admin: Wallet

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/StakeWeightedAllocationPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/StakeWeightedAllocationPolicy.test.ts
@@ -1,12 +1,13 @@
 import { ethers } from "hardhat"
 import { expect } from "chai"
-import { BigNumber, utils, ContractTransaction, Wallet } from "ethers"
 
 import { deployTestContracts, TestContracts } from "../deployTestContracts"
 import { advanceToTimestamp, getBlockTimestamp } from "../utils"
 import { deploySponsorshipWithoutFactory } from "../deploySponsorshipContract"
 
-const { parseEther, formatEther } = utils
+import type { BigNumber, ContractTransaction, Wallet } from "ethers"
+
+const { parseEther, formatEther } = ethers.utils
 
 describe("StakeWeightedAllocationPolicy", (): void => {
     let admin: Wallet

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/VoteKickPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/VoteKickPolicy.test.ts
@@ -5,7 +5,6 @@ import { deployTestContracts, TestContracts } from "../deployTestContracts"
 import { setupSponsorships, SponsorshipTestSetup } from "../setupSponsorships"
 import { advanceToTimestamp, getBlockTimestamp, VOTE_KICK, VOTE_NO_KICK, VOTE_START, VOTE_END } from "../utils"
 
-import type { MockRandomOracle } from "../../../../typechain"
 import type { BigNumber, Wallet } from "ethers"
 
 const { parseEther, getAddress, hexZeroPad } = ethers.utils

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/VoteKickPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/VoteKickPolicy.test.ts
@@ -509,7 +509,6 @@ describe("VoteKickPolicy", (): void => {
             const reviewerCount = +await contracts.streamrConfig.flagReviewerCount()
             const minimumStakeWei = await contracts.streamrConfig.minimumStakeWei()
             const flagStakeWei = await contracts.streamrConfig.flagStakeWei()
-            const oneEther = BigNumber.from("1000000000000000000")
             const slashingFraction = (await contracts.streamrConfig.slashingFraction())
             // const flagReviewerRewardWei = parseEther("1")
             // const flaggerRewardWei = parseEther("1")
@@ -529,7 +528,7 @@ describe("VoteKickPolicy", (): void => {
             const minimumStake = await sponsorship.minimumStakeOf(flagger.address)
             expect(minimumStake).to.equal(minimumStakeWei)
             // can't flag unless stake is slashingFraction of flagStakeWei
-            const flaggerStakeWei = max(minimumStake, flagStakeWei.mul(slashingFraction).div(oneEther).add(1))
+            const flaggerStakeWei = max(minimumStake, flagStakeWei.mul(slashingFraction).div(parseEther("1")).add(1))
             await expect(flagger.reduceStakeTo(sponsorship.address, flaggerStakeWei))
                 .to.emit(sponsorship, "StakeUpdate").withArgs(flagger.address, flaggerStakeWei, parseEther("0"))
 

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/VoteKickPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/VoteKickPolicy.test.ts
@@ -1,12 +1,14 @@
 import { ethers } from "hardhat"
-import { BigNumber, utils, Wallet } from "ethers"
 import { expect } from "chai"
 
 import { deployTestContracts, TestContracts } from "../deployTestContracts"
 import { setupSponsorships, SponsorshipTestSetup } from "../setupSponsorships"
 import { advanceToTimestamp, getBlockTimestamp, VOTE_KICK, VOTE_NO_KICK, VOTE_START, VOTE_END } from "../utils"
 
-const { parseEther, getAddress, hexZeroPad } = utils
+import type { MockRandomOracle } from "../../../../typechain"
+import type { BigNumber, Wallet } from "ethers"
+
+const { parseEther, getAddress, hexZeroPad } = ethers.utils
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function parseFlag(flagData: BigNumber) {

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/deployTestContracts.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/deployTestContracts.ts
@@ -1,5 +1,5 @@
 import { ethers as hardhatEthers, upgrades } from "hardhat"
-import { Wallet, utils} from "ethers"
+import type { Wallet } from "ethers"
 
 import type { Sponsorship, SponsorshipFactory, Operator, OperatorFactory, IAllocationPolicy, TestToken,
     StreamRegistryV4,
@@ -68,7 +68,7 @@ export async function deployOperatorFactory(contracts: Partial<TestContracts>, s
  */
 export async function deployTestContracts(signer: Wallet): Promise<TestContracts> {
     const token = await (await getContractFactory("TestToken", { signer })).deploy("TestToken", "TEST")
-    await (await token.mint(signer.address, utils.parseEther("1000000"))).wait()
+    await (await token.mint(signer.address, "1000000000000000000000000")).wait() // 1M tokens
 
     const streamrConfig = await (await getContractFactory("StreamrConfig", { signer })).deploy()
     await streamrConfig.deployed()

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/deployTestContracts.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/deployTestContracts.ts
@@ -121,7 +121,7 @@ export async function deployTestContracts(signer: Wallet): Promise<TestContracts
 
     const streamRegistryFactory = await getContractFactory("StreamRegistryV4", { signer })
     const streamRegistry = await upgrades.deployProxy(streamRegistryFactory,
-        [hardhatEthers.constants.AddressZero, Wallet.createRandom().address], { kind: "uups" }) as StreamRegistryV4
+        [hardhatEthers.constants.AddressZero, hardhatEthers.Wallet.createRandom().address], { kind: "uups" }) as StreamRegistryV4
 
     await (await streamrConfig!.setStreamRegistryAddress(streamRegistry.address)).wait()
 

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/setupSponsorships.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/setupSponsorships.ts
@@ -1,13 +1,13 @@
 import { ethers as hardhatEthers } from "hardhat"
-import { BigNumber, utils, Wallet } from "ethers"
 
 import { deployOperatorFactory, TestContracts } from "./deployTestContracts"
 import { deploySponsorship } from "./deploySponsorshipContract"
 import { deployOperatorContract } from "./deployOperatorContract"
 
+import type { BigNumber, Wallet } from "ethers"
 import type { Sponsorship, Operator, OperatorFactory, TestToken } from "../../../typechain"
 
-const { parseEther, id } = utils
+const { parseEther, id } = hardhatEthers.utils
 
 export interface SponsorshipTestSetup {
     token: TestToken
@@ -65,7 +65,7 @@ export async function setupSponsorships(contracts: TestContracts, operatorCounts
 
     // no risk of nonce collisions in Promise.all since each operator has their own separate nonce
     // see OperatorFactory:_deployOperator for how saltSeed is used in CREATE2
-    const operators = await Promise.all(signers.map((signer) => 
+    const operators = await Promise.all(signers.map((signer) =>
         deployOperatorContract(newContracts, signer, operatorsCutFraction, { metadata: "{}" }, saltSeed)))
     const operatorsPerSponsorship = splitBy(operators, operatorCounts)
 

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/setupSponsorships.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/setupSponsorships.ts
@@ -52,7 +52,7 @@ export async function setupSponsorships(contracts: TestContracts, operatorCounts
     const signers = hardhatSigners.slice(0, totalOperatorCount)
 
     // clean deployer wallet starts from nothing => needs ether to deploy Operator etc.
-    const deployer = new Wallet(id(saltSeed), admin.provider) // id turns string into bytes32
+    const deployer = new hardhatEthers.Wallet(id(saltSeed), admin.provider) // id turns string into bytes32
     await (await admin.sendTransaction({ to: deployer.address, value: parseEther("1") })).wait()
     // console.log("deployer: %s", addr(deployer))
 
@@ -81,7 +81,7 @@ export async function setupSponsorships(contracts: TestContracts, operatorCounts
     for (let i = 0; i < sponsorshipCount; i++) {
         const staked = operatorsPerSponsorship[i]
         const sponsorship = await deploySponsorship(contracts, {
-            allocationWeiPerSecond: BigNumber.from(0),
+            allocationWeiPerSecond: parseEther("0"),
             penaltyPeriodSeconds: 0,
             ...sponsorshipSettings
         })

--- a/packages/network-contracts/test/hardhat/Registries/StreamRegistry.test.ts
+++ b/packages/network-contracts/test/hardhat/Registries/StreamRegistry.test.ts
@@ -1,10 +1,10 @@
 import { upgrades, ethers } from "hardhat"
 import { expect } from "chai"
-import { BigNumber, Wallet } from "ethers"
 import Debug from "debug"
 
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 
+import type { BigNumber, Wallet } from "ethers"
 import type { MinimalForwarder, StreamRegistry, StreamRegistryV4 } from "../../../typechain"
 
 import { getEIP2771MetaTx } from "./getEIP2771MetaTx"

--- a/packages/network-contracts/test/hardhat/Registries/StreamRegistry.test.ts
+++ b/packages/network-contracts/test/hardhat/Registries/StreamRegistry.test.ts
@@ -2,14 +2,14 @@ import { upgrades, ethers } from "hardhat"
 import { expect } from "chai"
 import Debug from "debug"
 
-import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
-
-import type { BigNumber, Wallet } from "ethers"
-import type { MinimalForwarder, StreamRegistry, StreamRegistryV4 } from "../../../typechain"
+import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers"
 
 import { getEIP2771MetaTx } from "./getEIP2771MetaTx"
+import type { MinimalForwarder, StreamRegistry, StreamRegistryV4 } from "../../../typechain"
 
 const log = Debug("Streamr::test::StreamRegistryV4")
+
+const { Wallet, BigNumber } = ethers
 
 // eslint-disable-next-line no-unused-vars
 enum PermissionType { Edit = 0, Delete, Publish, Subscribe, Share }
@@ -29,7 +29,7 @@ describe("StreamRegistry", async (): Promise<void> => {
     let registryFromUser1: StreamRegistryV4
     let registryFromMigrator: StreamRegistryV4
     let minimalForwarderFromUser0: MinimalForwarder
-    let MAX_INT: BigNumber
+    let MAX_INT: any
     let blocktime: number
     // let registryFromUser1: StreamRegistry
     let adminAddress: string
@@ -76,10 +76,10 @@ describe("StreamRegistry", async (): Promise<void> => {
         await registryV2FromAdmin.revokeRole(await registryV2FromAdmin.TRUSTED_ROLE(), wallets[0].address)
         // eslint-disable-next-line require-atomic-updates
         registry = await streamRegistryFactoryV4Tx.deployed() as StreamRegistryV4
-        registryFromAdmin = registry.connect(wallets[0])
-        registryFromUser0 = registry.connect(wallets[1])
-        registryFromUser1 = registry.connect(wallets[2])
-        registryFromMigrator = registry.connect(wallets[3])
+        registryFromAdmin = registry.connect(wallets[0] as any)
+        registryFromUser0 = registry.connect(wallets[1] as any)
+        registryFromUser1 = registry.connect(wallets[2] as any)
+        registryFromMigrator = registry.connect(wallets[3] as any)
         MAX_INT = await registry.MAX_INT()
         await registryFromAdmin.grantRole(await registry.TRUSTED_ROLE(), trustedAddress)
     })
@@ -705,7 +705,7 @@ describe("StreamRegistry", async (): Promise<void> => {
             forwarder = minimalForwarderFromUser0,
             signer = ethers.Wallet.createRandom(),
             gas
-        }: { forwarder?: MinimalForwarder; signer?: Wallet; gas?: string } = {}) {
+        }: { forwarder?: MinimalForwarder; signer?: typeof Wallet; gas?: string } = {}) {
             // signerWallet is creating and signing transaction, user0 is posting it and paying for gas
             // in the positive case signkey is the same as signerWallet.privateKey
             const path = "/path" + Wallet.createRandom().address

--- a/packages/network-contracts/test/hardhat/Registries/getEIP2771MetaTx.ts
+++ b/packages/network-contracts/test/hardhat/Registries/getEIP2771MetaTx.ts
@@ -1,7 +1,10 @@
 import { ethers } from "hardhat"
-import { utils, Wallet } from "ethers"
 import { signTypedData, SignTypedDataVersion, TypedMessage } from "@metamask/eth-sig-util"
 import { MinimalForwarder } from "../../../typechain"
+
+import type { Wallet } from "ethers"
+
+const { arrayify } = ethers.utils
 
 interface EIP2771MetaTx {
     request: {
@@ -53,7 +56,7 @@ export async function getEIP2771MetaTx(to: string, data: string, forwarder: Mini
     }
     const options = {
         data: d,
-        privateKey: utils.arrayify(signer.privateKey) as Buffer,
+        privateKey: arrayify(signer.privateKey) as Buffer,
         version: SignTypedDataVersion.V4,
     }
     const signature = signTypedData(options)


### PR DESCRIPTION
don't mix type and object imports, from "ethers" we only get types; the utils we get from hardhat's version