### PR TITLE
ETH-293: Added numeric precision to StakeWeightedAllocationPolicy

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
@@ -16,6 +16,7 @@ import "./SponsorshipPolicies/IKickPolicy.sol";
 import "./SponsorshipPolicies/IAllocationPolicy.sol";
 import "./StreamrConfig.sol";
 
+import "hardhat/console.sol";
 
 /**
  * `Sponsorship` ("Stream Agreement") holds the sponsors' tokens and allocates them to operators
@@ -90,7 +91,7 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
     uint public minOperatorCount;
     uint public minHorizonSeconds;
     uint public remainingWei;
-    uint public earningsWei; // only the IAllocationPolicy should modify this!
+    uint public earningsWei; // allocated but not withdrawn tokens; only the IAllocationPolicy should modify this!
 
     function getMyStake() public view returns (uint) {
         return stakedWei[_msgSender()];
@@ -334,6 +335,7 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
         // send out both allocations and stake
         uint paidOutEarningsWei = _withdraw(operator);
         uint paidOutStakeWei = stakedWei[operator];
+        console.log("  payout", paidOutEarningsWei, paidOutStakeWei);
 
         operatorCount -= 1;
         totalStakedWei -= paidOutStakeWei;

--- a/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
@@ -16,8 +16,6 @@ import "./SponsorshipPolicies/IKickPolicy.sol";
 import "./SponsorshipPolicies/IAllocationPolicy.sol";
 import "./StreamrConfig.sol";
 
-import "hardhat/console.sol";
-
 /**
  * `Sponsorship` ("Stream Agreement") holds the sponsors' tokens and allocates them to operators
  * Those tokens are the *sponsorship* that the *sponsor* puts on servicing the stream
@@ -335,7 +333,6 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
         // send out both allocations and stake
         uint paidOutEarningsWei = _withdraw(operator);
         uint paidOutStakeWei = stakedWei[operator];
-        console.log("  payout", paidOutEarningsWei, paidOutStakeWei);
 
         operatorCount -= 1;
         totalStakedWei -= paidOutStakeWei;

--- a/packages/network-contracts/contracts/OperatorTokenomics/SponsorshipPolicies/StakeWeightedAllocationPolicy.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/SponsorshipPolicies/StakeWeightedAllocationPolicy.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.13;
 import "./IAllocationPolicy.sol";
 import "../Sponsorship.sol";
 
-import "hardhat/console.sol";
 
 // allocation happens over time, so there's necessarily lots of "relying on time" here
 /* solhint-disable not-rely-on-time */
@@ -13,7 +12,7 @@ import "hardhat/console.sol";
 contract StakeWeightedAllocationPolicy is IAllocationPolicy, Sponsorship {
     struct LocalStorage {
         uint incomePerSecond;           // wei, total income velocity, distributed to operators, decided by sponsor upon creation
-        uint cumulativeWeiPer1e36Stake; // cumulative income over time, per 1e36 stake-wei, with added accuracy to avoid rounding to zero
+        uint cumulativeWeiPer1e36Stake; // cumulative income over time, per 1e36 stake-wei, with added precision to avoid rounding to zero in calculations
 
         /**
          * The per-1e36-stake allocation (1e36 * new-earnings-wei / total-stake-wei) of each operator is
@@ -23,8 +22,8 @@ contract StakeWeightedAllocationPolicy is IAllocationPolicy, Sponsorship {
          *   so we save the result of the integral up to that point and continue integrating from there with the new weight.
          */
         mapping(address => uint) cumulativeReference;
-        /** Remember how much earnings there were before the last cumulativeReference update */
-        mapping(address => uint) earningsBeforeReferenceUpdate;
+        /** Remember how much earnings there were before the last cumulativeReference update, scaled by 1e36 for numerical reasons */
+        mapping(address => uint) earningsBeforeReferenceUpdateTimes1e36;
 
         // the current unallocated funds will run out if more sponsorship is not added
         uint defaultedWei; // lost income during the current insolvency; reported in InsolvencyEnded event, not used in allocations
@@ -55,13 +54,13 @@ contract StakeWeightedAllocationPolicy is IAllocationPolicy, Sponsorship {
         if (stakedWei[operator] == 0) { return 0; }
         LocalStorage storage local = localData();
         (uint newAllocationsWei,) = calculateSinceLastUpdate();
+
+        // Round up if the remainder is less than what's possible to intentionally cause with incomePerSecond's precision:
+        //   minimum non-zero value for incomePerSecond is 1 wei/second; 1e25/1e36 = 1/1e11 of 1 wei/second < 1 wei / 300 years
+        // This fixes rounding errors such as 10/3 * 3 = 9.9999... = 9, now it will give 10 which is correct
         uint cumulativeWeiPer1e36Stake = local.cumulativeWeiPer1e36Stake + newAllocationsWei * 1e36 / local.lastUpdateTotalStake;
         uint newEarningsPer1e36Stake = cumulativeWeiPer1e36Stake - localData().cumulativeReference[operator];
-        console.log("getEarningsWei", cumulativeWeiPer1e36Stake, newEarningsPer1e36Stake);
-        console.log(localData().earningsBeforeReferenceUpdate[operator], stakedWei[operator], stakedWei[operator] * newEarningsPer1e36Stake / 1e36,
-            localData().earningsBeforeReferenceUpdate[operator] + stakedWei[operator] * newEarningsPer1e36Stake / 1e36);
-        // TODO: smarter rounding? If the remainder is less than what's possible with incomePerSecond wei-precision, then round up
-        return localData().earningsBeforeReferenceUpdate[operator] + stakedWei[operator] * newEarningsPer1e36Stake / 1e36;
+        return (localData().earningsBeforeReferenceUpdateTimes1e36[operator] + stakedWei[operator] * newEarningsPer1e36Stake + 1e25) / 1e36;
     }
 
     /**
@@ -112,7 +111,6 @@ contract StakeWeightedAllocationPolicy is IAllocationPolicy, Sponsorship {
 
         if (newAllocationsWei > 0) {
             // move funds from sponsorship to earnings, add to the cumulativeWeiPer1e36Stake integral
-            console.log("update", newAllocationsWei, localVars.lastUpdateTotalStake);
             earningsWei += newAllocationsWei;
             remainingWei -= newAllocationsWei;
             localVars.cumulativeWeiPer1e36Stake += newAllocationsWei * 1e36 / localVars.lastUpdateTotalStake;
@@ -142,7 +140,7 @@ contract StakeWeightedAllocationPolicy is IAllocationPolicy, Sponsorship {
     /** When operator leaves, its state is cleared as if it had never joined */
     function onLeave(address operator) external {
         update();
-        delete localData().earningsBeforeReferenceUpdate[operator];
+        delete localData().earningsBeforeReferenceUpdateTimes1e36[operator];
         delete localData().cumulativeReference[operator];
     }
 
@@ -156,9 +154,9 @@ contract StakeWeightedAllocationPolicy is IAllocationPolicy, Sponsorship {
         // must use pre-increase stake for the past period => undo the stakeChangeWei just for the calculation
         uint oldStakeWei = uint(int(stakedWei[operator]) - stakeChangeWei);
 
-        // Reference Point Update => move new earnings since last reference update to earningsBeforeReferenceUpdate
+        // Reference Point Update => move (scaled) new earnings since last reference update to earningsBeforeReferenceUpdateTimes1e36
         uint newEarningsPer1e36Stake = local.cumulativeWeiPer1e36Stake - local.cumulativeReference[operator];
-        local.earningsBeforeReferenceUpdate[operator] += oldStakeWei * newEarningsPer1e36Stake / 1e36;
+        local.earningsBeforeReferenceUpdateTimes1e36[operator] += oldStakeWei * newEarningsPer1e36Stake;
         local.cumulativeReference[operator] = local.cumulativeWeiPer1e36Stake; // <- this is the reference update
     }
 
@@ -166,15 +164,14 @@ contract StakeWeightedAllocationPolicy is IAllocationPolicy, Sponsorship {
     function onWithdraw(address operator) external returns (uint payoutWei) {
         update();
 
-        // calculate payout FIRST, before zeroing earningsBeforeReferenceUpdate
+        // calculate payout before zeroing earningsBeforeReferenceUpdateTimes1e36, because it's used in the calculation
         payoutWei = getEarningsWei(operator);
-        console.log("onWithdraw", earningsWei, payoutWei);
         earningsWei -= payoutWei;
 
         // update reference point, also zero the "unpaid earnings" because they will be paid out
         LocalStorage storage local = localData();
         local.cumulativeReference[operator] = local.cumulativeWeiPer1e36Stake;
-        local.earningsBeforeReferenceUpdate[operator] = 0;
+        local.earningsBeforeReferenceUpdateTimes1e36[operator] = 0;
     }
 
     function onSponsor(address, uint amount) external {

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/StakeWeightedAllocationPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/StakeWeightedAllocationPolicy.test.ts
@@ -5,9 +5,12 @@ import { deployTestContracts, TestContracts } from "../deployTestContracts"
 import { advanceToTimestamp, getBlockTimestamp } from "../utils"
 import { deploySponsorshipWithoutFactory } from "../deploySponsorshipContract"
 
-import type { BigNumber, ContractTransaction, Wallet } from "ethers"
+import type { Wallet } from "ethers"
 
-const { parseEther, formatEther } = ethers.utils
+const {
+    BigNumber,
+    utils: { parseEther, formatEther }
+} = ethers
 
 describe("StakeWeightedAllocationPolicy", (): void => {
     let admin: Wallet
@@ -306,16 +309,16 @@ describe("StakeWeightedAllocationPolicy", (): void => {
             sponsorship.address,
             parseEther("4000"),
             operator2.address
-        ) as ContractTransaction).wait()
+        )).wait()
 
         // timeAtStart + 2001: money runs out (+1 because joins happen at +1)
 
         await advanceToTimestamp(timeAtStart + 3000, "Operator 2 leaves")
-        const leave2Tr = await (await sponsorship.connect(operator2).unstake() as ContractTransaction).wait()
+        const leave2Tr = await (await sponsorship.connect(operator2).unstake()).wait()
         const insolvencyEvent = leave2Tr.events?.find((e) => e.event == "InsolvencyStarted")
 
         await advanceToTimestamp(timeAtStart + 4000, "Operator 1 leaves")
-        await (await sponsorship.connect(operator).unstake() as ContractTransaction).wait()
+        await (await sponsorship.connect(operator).unstake()).wait()
 
         const tokensOperator1Actual = (await token.balanceOf(operator.address)).sub(tokensOperator1Before)
         const tokensOperator2Actual = (await token.balanceOf(operator2.address)).sub(tokensOperator2Before)
@@ -357,7 +360,7 @@ describe("StakeWeightedAllocationPolicy", (): void => {
         const tr = await (await sponsorship.sponsor(parseEther("10000"))).wait()
         const insolvencyStartEvent = tr.events?.find((e) => e.event == "InsolvencyStarted")
         const insolvencyEndEvent = tr.events?.find((e) => e.event == "InsolvencyEnded")
-        const insolvencyStartTime = ((insolvencyStartEvent?.args?.[0]) as BigNumber).toNumber()
+        const insolvencyStartTime = insolvencyStartEvent?.args?.[0].toNumber() as number
 
         await advanceToTimestamp(timeAtStart + 4000, "Operator 2 leaves")
         await (await sponsorship.connect(operator2).unstake()).wait()
@@ -373,7 +376,7 @@ describe("StakeWeightedAllocationPolicy", (): void => {
         // event InsolvencyStarted(uint startTimeStamp);
         // event InsolvencyEnded(uint endTimeStamp, uint defaultedWeiPerStake, uint defaultedWei);
         expect(insolvencyStartTime - timeAtStart).to.equal(2001)
-        expect(insolvencyEndEvent?.args?.map((a: BigNumber) => a.toString())).to.deep.equal([
+        expect(insolvencyEndEvent?.args?.map((a) => a.toString())).to.deep.equal([
             // timeAtStart + 2001).toString(), // +1 because all tx happen one second "late" in test env
             (timeAtStart + 3001).toString(),
             parseEther("1000").div("2000").toString(),     // 2000 full token total stake
@@ -434,8 +437,8 @@ describe("StakeWeightedAllocationPolicy", (): void => {
 
         // event InsolvencyStarted(uint startTimeStamp);
         // event InsolvencyEnded(uint endTimeStamp, uint defaultedWeiPerStake, uint defaultedWei);
-        expect(insolvencyStartEvent?.args?.map((a: BigNumber) => a.toNumber())).to.deep.equal([timeAtStart + 1001])
-        expect(insolvencyEndEvent?.args?.map((a: BigNumber) => a.toString())).to.deep.equal([
+        expect(insolvencyStartEvent?.args?.map((a) => a.toNumber())).to.deep.equal([timeAtStart + 1001])
+        expect(insolvencyEndEvent?.args?.map((a) => a.toString())).to.deep.equal([
             // (timeAtStart + 1001).toString(),
             (timeAtStart + 3001).toString(), // +1 because all tx happen one second "late" in test env
             parseEther("1.5").toString(),
@@ -467,7 +470,7 @@ describe("StakeWeightedAllocationPolicy", (): void => {
         const newTokens = (await token.balanceOf(operator.address)).sub(tokensBefore)
 
         // event InsolvencyStarted(uint startTimeStamp);
-        expect(insolvencyEvent?.args?.map((a: BigNumber) => a.toNumber())).to.deep.equal([timeAtStart + 1001])
+        expect(insolvencyEvent?.args?.map((a) => a.toNumber())).to.deep.equal([timeAtStart + 1001])
         expect(formatEther(newTokens)).to.equal("1000.0")
     })
 
@@ -513,8 +516,8 @@ describe("StakeWeightedAllocationPolicy", (): void => {
 
         // event InsolvencyStarted(uint startTimeStamp);
         // event InsolvencyEnded(uint endTimeStamp, uint defaultedWeiPerStake, uint defaultedWei);
-        expect(insolvencyStartEvent?.args?.map((a: BigNumber) => a.toNumber())).to.deep.equal([timeAtStart + 1001])
-        expect(insolvencyEndEvent?.args?.map((a: BigNumber) => a.toString())).to.deep.equal([
+        expect(insolvencyStartEvent?.args?.map((a) => a.toNumber())).to.deep.equal([timeAtStart + 1001])
+        expect(insolvencyEndEvent?.args?.map((a) => a.toString())).to.deep.equal([
             // (timeAtStart + 1001).toString(),
             (timeAtStart + 4001).toString(), // +1 because all tx happen one second "late" in test env
             parseEther("2").toString(),
@@ -578,8 +581,8 @@ describe("StakeWeightedAllocationPolicy", (): void => {
 
         // event InsolvencyStarted(uint startTimeStamp);
         // event InsolvencyEnded(uint endTimeStamp, uint defaultedWeiPerStake, uint defaultedWei);
-        expect(insolvencyStartEvent?.args?.map((a: BigNumber) => a.toNumber())).to.deep.equal([timeAtStart + 2001])
-        expect(insolvencyEndEvent?.args?.map((a: BigNumber) => a.toString())).to.deep.equal([
+        expect(insolvencyStartEvent?.args?.map((a) => a.toNumber())).to.deep.equal([timeAtStart + 2001])
+        expect(insolvencyEndEvent?.args?.map((a) => a.toString())).to.deep.equal([
             (timeAtStart + 5001).toString(), // +1 because all tx happen one second "late" in test env
             parseEther("2.0").toString(),
             parseEther("3000").toString()
@@ -627,8 +630,8 @@ describe("StakeWeightedAllocationPolicy", (): void => {
 
         // event InsolvencyStarted(uint startTimeStamp);
         // event InsolvencyEnded(uint endTimeStamp, uint defaultedWeiPerStake, uint defaultedWei);
-        expect(insolvencyStartEvent?.args?.map((a: BigNumber) => a.toNumber())).to.deep.equal([timeAtStart + 1001])
-        expect(insolvencyEndEvent?.args?.map((a: BigNumber) => a.toString())).to.deep.equal([
+        expect(insolvencyStartEvent?.args?.map((a) => a.toNumber())).to.deep.equal([timeAtStart + 1001])
+        expect(insolvencyEndEvent?.args?.map((a) => a.toString())).to.deep.equal([
             (timeAtStart + 2001).toString(), // +1 because all tx happen one second "late" in test env
             parseEther("0.5").toString(),
             parseEther("1000").toString()
@@ -676,8 +679,8 @@ describe("StakeWeightedAllocationPolicy", (): void => {
 
         // event InsolvencyStarted(uint startTimeStamp);
         // event InsolvencyEnded(uint endTimeStamp, uint defaultedWeiPerStake, uint defaultedWei);
-        expect(insolvencyStartEvent?.args?.map((a: BigNumber) => a.toNumber())).to.deep.equal([timeAtStart + 2001])
-        expect(insolvencyEndEvent?.args?.map((a: BigNumber) => a.toString())).to.deep.equal([
+        expect(insolvencyStartEvent?.args?.map((a) => a.toNumber())).to.deep.equal([timeAtStart + 2001])
+        expect(insolvencyEndEvent?.args?.map((a) => a.toString())).to.deep.equal([
             (timeAtStart + 3001).toString(), // +1 because all tx happen one second "late" in test env
             parseEther("1.0").toString(),
             parseEther("1000").toString()
@@ -737,5 +740,172 @@ describe("StakeWeightedAllocationPolicy", (): void => {
         const sponsorship = await deploySponsorshipWithoutFactory(contracts)
         const allocation = await sponsorship.getEarnings(operator.address)
         expect(allocation.toString()).to.equal("0")
+    })
+
+    describe("Wei-scale allocations and stakes", function() {
+        it("allocates correctly even when incomePerSecond is wei-scale", async function(): Promise<void> {
+            // the numbers here also intentionally cause rounding errors, e.g. 1/12 for t=1000...2000
+            //     t0       : operator1 joins, stakes 6 (6 : 0)
+            // t = t0 + 1000: operator2 joins, stakes 6 (6 : 6)
+            // t = t0 + 2000: operator2 stake -> 4      (6 : 4)
+            // t = t0 + 3000: operator1 stake -> 4      (4 : 4)
+            // t = t0 + 4000: operator2 leaves          (4 : 0)
+            // t = t0 + 5000: operator1 leaves          (0 : 0)
+            // operator1 should have 1000 + 500 + 600 + 500 + 1000 = 3600
+            // operator2 should have        500 + 400 + 500        = 1400
+            const { token } = contracts
+            const sponsorship = await deploySponsorshipWithoutFactory(contracts, {
+                allocationWeiPerSecond: BigNumber.from("1")
+            })
+            await (await sponsorship.sponsor(parseEther("20000"))).wait()
+            const tokensOperator1Before = await token.balanceOf(operator.address)
+            const tokensOperator2Before = await token.balanceOf(operator2.address)
+            const timeAtStart = await getBlockTimestamp()
+
+            await advanceToTimestamp(timeAtStart, "Operator 1 joins")
+            await (await token.connect(operator).transferAndCall(sponsorship.address, parseEther("600"), operator.address)).wait()
+
+            await advanceToTimestamp(timeAtStart + 1000, "Operator 2 joins")
+            await (await token.connect(operator2).transferAndCall(sponsorship.address, parseEther("600"), operator2.address)).wait()
+
+            await advanceToTimestamp(timeAtStart + 2000, "Operator 2 reduces stake 600 -> 400")
+            await (await sponsorship.connect(operator2).reduceStakeTo(parseEther("400"))).wait()
+
+            await advanceToTimestamp(timeAtStart + 3000, "Operator 1 reduces stake 600 -> 400")
+            await (await sponsorship.connect(operator).reduceStakeTo(parseEther("400"))).wait()
+
+            await advanceToTimestamp(timeAtStart + 4000, "Operator 2 leaves")
+            await (await sponsorship.connect(operator2).unstake()).wait()
+
+            await advanceToTimestamp(timeAtStart + 5000, "Operator 1 leaves")
+            await (await sponsorship.connect(operator).unstake()).wait()
+
+            const newTokens1 = (await token.balanceOf(operator.address)).sub(tokensOperator1Before)
+            const newTokens2 = (await token.balanceOf(operator2.address)).sub(tokensOperator2Before)
+
+            expect(newTokens1).to.equal(3600)
+            expect(newTokens2).to.equal(1400)
+        })
+
+        it("allocates correctly even when incomePerSecond and stakes are wei-scale", async function(): Promise<void> {
+            // time since start   0...3...13...15
+            // operator1 gets       3 + 9 +  0    = 12
+            // operator2 gets       0 + 1 +  2    =  3
+            const { token, streamrConfig } = contracts
+            const sponsorship = await deploySponsorshipWithoutFactory(contracts, {
+                allocationWeiPerSecond: BigNumber.from("1")
+            })
+            await (await streamrConfig.setFlaggerRewardWei("0")).wait()
+            await (await streamrConfig.setFlagReviewerRewardWei("0")).wait()
+            expect(await streamrConfig.minimumStakeWei()).to.equal(0)
+
+            await (await sponsorship.sponsor("16")).wait()
+            const tokensOperator1Before = await token.balanceOf(operator.address)
+            const tokensOperator2Before = await token.balanceOf(operator2.address)
+            const timeAtStart = await getBlockTimestamp()
+
+            await advanceToTimestamp(timeAtStart, "Operator 1 joins")
+            await (await token.connect(operator).transferAndCall(sponsorship.address, "9", operator.address)).wait()
+
+            await advanceToTimestamp(timeAtStart + 3, "Operator 2 joins")
+            await (await token.connect(operator2).transferAndCall(sponsorship.address, "1", operator2.address)).wait()
+
+            // Doing this still breaks it because the sub-wei earnings are discarded while nothing is paid out
+            // Not worth fixing since we're never going to have wei-scale stakes. Cool it mostly still works though :)
+            // await advanceToTimestamp(timeAtStart + 7, "Operator 2 does a withdraw")
+            // await (await sponsorship.connect(operator2).withdraw()).wait()
+
+            await advanceToTimestamp(timeAtStart + 13, "Operator 1 leaves")
+            await (await sponsorship.connect(operator).unstake()).wait()
+
+            await advanceToTimestamp(timeAtStart + 15, "Operator 2 leaves")
+            await (await sponsorship.connect(operator2).unstake()).wait()
+
+            const newTokens1 = (await token.balanceOf(operator.address)).sub(tokensOperator1Before)
+            const newTokens2 = (await token.balanceOf(operator2.address)).sub(tokensOperator2Before)
+
+            expect(newTokens1).to.equal(12)
+            expect(newTokens2).to.equal(3)
+            expect(await token.balanceOf(sponsorship.address)).to.equal(1)
+        })
+
+        it("allocates correctly even when some stakes are wei-scale", async function(): Promise<void> {
+            // time since start   0...3...13...15
+            // operator1 gets       3 + 10* +  0    = 13*
+            // operator2 gets       0 +  0* +  2    =  2*
+            // where * = 10 wei that went to op2 instead of op1
+            const { token, streamrConfig } = contracts
+            const sponsorship = await deploySponsorshipWithoutFactory(contracts)
+            await (await streamrConfig.setFlaggerRewardWei("0")).wait()
+            await (await streamrConfig.setFlagReviewerRewardWei("0")).wait()
+            expect(await streamrConfig.minimumStakeWei()).to.equal(0)
+
+            await (await sponsorship.sponsor(parseEther("16"))).wait()
+            const tokensOperator1Before = await token.balanceOf(operator.address)
+            const tokensOperator2Before = await token.balanceOf(operator2.address)
+            const timeAtStart = await getBlockTimestamp()
+
+            await advanceToTimestamp(timeAtStart, "Operator 1 joins")
+            await (await token.connect(operator).transferAndCall(sponsorship.address, parseEther("1"), operator.address)).wait()
+
+            await advanceToTimestamp(timeAtStart + 3, "Operator 2 joins")
+            await (await token.connect(operator2).transferAndCall(sponsorship.address, "1", operator2.address)).wait()
+
+            // Doing this still breaks it because the sub-wei earnings are discarded while nothing is paid out
+            // Not worth fixing since we're never going to have wei-scale stakes. Cool it mostly still works though :)
+            // await advanceToTimestamp(timeAtStart + 7, "Operator 2 does a withdraw")
+            // await (await sponsorship.connect(operator2).withdraw()).wait()
+
+            await advanceToTimestamp(timeAtStart + 13, "Operator 1 leaves")
+            await (await sponsorship.connect(operator).unstake()).wait()
+
+            await advanceToTimestamp(timeAtStart + 15, "Operator 2 leaves")
+            await (await sponsorship.connect(operator2).unstake()).wait()
+
+            const newTokens1 = (await token.balanceOf(operator.address)).sub(tokensOperator1Before)
+            const newTokens2 = (await token.balanceOf(operator2.address)).sub(tokensOperator2Before)
+
+            expect(newTokens1).to.equal(parseEther("13").sub("10"))
+            expect(newTokens2).to.equal(parseEther("2").add("10"))
+            expect(formatEther(await token.balanceOf(sponsorship.address))).to.equal("1.0")
+        })
+
+        it("allocates correctly even when allocation AND some stakes are wei-scale", async function(): Promise<void> {
+            // time since start   0...3...13...15
+            // operator1 gets       3 + 10* +  0    = 13*
+            // operator2 gets       0 +  0* +  2    =  2*
+            // where * = 10 wei that went to op2 instead of op1
+            const { token, streamrConfig } = contracts
+            const sponsorship = await deploySponsorshipWithoutFactory(contracts, {
+                allocationWeiPerSecond: BigNumber.from("1")
+            })
+            await (await streamrConfig.setFlaggerRewardWei("0")).wait()
+            await (await streamrConfig.setFlagReviewerRewardWei("0")).wait()
+            expect(await streamrConfig.minimumStakeWei()).to.equal(0)
+
+            await (await sponsorship.sponsor("16")).wait()
+            const tokensOperator1Before = await token.balanceOf(operator.address)
+            const tokensOperator2Before = await token.balanceOf(operator2.address)
+            const timeAtStart = await getBlockTimestamp()
+
+            await advanceToTimestamp(timeAtStart, "Operator 1 joins")
+            await (await token.connect(operator).transferAndCall(sponsorship.address, parseEther("1"), operator.address)).wait()
+
+            await advanceToTimestamp(timeAtStart + 3, "Operator 2 joins")
+            await (await token.connect(operator2).transferAndCall(sponsorship.address, "1", operator2.address)).wait()
+
+            await advanceToTimestamp(timeAtStart + 13, "Operator 1 leaves")
+            await (await sponsorship.connect(operator).unstake()).wait()
+
+            await advanceToTimestamp(timeAtStart + 15, "Operator 2 leaves")
+            await (await sponsorship.connect(operator2).unstake()).wait()
+
+            const newTokens1 = (await token.balanceOf(operator.address)).sub(tokensOperator1Before)
+            const newTokens2 = (await token.balanceOf(operator2.address)).sub(tokensOperator2Before)
+
+            expect(newTokens1).to.equal(13)
+            expect(newTokens2).to.equal(2)
+            expect(await token.balanceOf(sponsorship.address)).to.equal(1)
+        })
     })
 })

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/StakeWeightedAllocationPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/StakeWeightedAllocationPolicy.test.ts
@@ -812,6 +812,8 @@ describe("StakeWeightedAllocationPolicy", (): void => {
 
             // Doing this still breaks it because the sub-wei earnings are discarded while nothing is paid out
             // Not worth fixing since we're never going to have wei-scale stakes. Cool it mostly still works though :)
+            // Fixing it would complicate the withdraw where we couldn't just zero the earningsBeforeReferenceUpdateTimes1e36
+            //   so we could remember the wei-fractions that are left behind. But maybe we can ignore wei-fractions.
             // await advanceToTimestamp(timeAtStart + 7, "Operator 2 does a withdraw")
             // await (await sponsorship.connect(operator2).withdraw()).wait()
 
@@ -850,11 +852,6 @@ describe("StakeWeightedAllocationPolicy", (): void => {
 
             await advanceToTimestamp(timeAtStart + 3, "Operator 2 joins")
             await (await token.connect(operator2).transferAndCall(sponsorship.address, "1", operator2.address)).wait()
-
-            // Doing this still breaks it because the sub-wei earnings are discarded while nothing is paid out
-            // Not worth fixing since we're never going to have wei-scale stakes. Cool it mostly still works though :)
-            // await advanceToTimestamp(timeAtStart + 7, "Operator 2 does a withdraw")
-            // await (await sponsorship.connect(operator2).withdraw()).wait()
 
             await advanceToTimestamp(timeAtStart + 13, "Operator 1 leaves")
             await (await sponsorship.connect(operator).unstake()).wait()


### PR DESCRIPTION
It can now tolerate 1 wei/second type of "absurd" but possible incomePerSecond values.

It can also tolerate 1 wei stake type of cases that are impossible with current minimum stake (decided by flagging+reviewer rewards).