### PR TITLE
Test cleanups

### DIFF
--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
@@ -81,61 +81,6 @@ describe("Operator contract", (): void => {
         await (await sharedContracts.streamrConfig.setProtocolFeeBeneficiary(protocolFeeBeneficiary.address)).wait()
     })
 
-    describe("Delegator functionality", (): void => {
-        it("balanceInData returns 0 if delegator is not delegated or has 0 balance", async function(): Promise<void> {
-            const { token: dataToken } = sharedContracts
-            await setTokens(delegator, "1000")
-            const { operator } = await deployOperator(operatorWallet)
-            expect(await operator.connect(delegator).balanceInData(delegator.address)).to.equal(0)
-
-            await (await dataToken.connect(delegator).transferAndCall(operator.address, parseEther("1000"), "0x")).wait()
-            expect(await operator.connect(delegator).balanceInData(delegator.address)).to.equal(parseEther("1000"))
-
-            await (await operator.connect(delegator).undelegate(parseEther("1000"))).wait()
-            expect(await operator.connect(delegator).balanceInData(delegator.address)).to.equal(0)
-        })
-
-        it("returns the correct queue position for a delegator not in queue", async function(): Promise<void> {
-            const { token } = sharedContracts
-            await setTokens(delegator, "1000")
-            await setTokens(delegator2, "1000")
-            await setTokens(delegator3, "1000")
-            const { operator } = await deployOperator(operatorWallet)
-            const sponsorship  = await deploySponsorship(sharedContracts)
-
-            // delegator can query his position in the queue without delegating
-            expect(await operator.queuePositionOf(delegator.address)).to.equal(1) // not in queue
-
-            // all delegators delegate to operator
-            // delegator and delegator2 are in the queue => returns position in front of him + himself
-            // delegator3 is not in the queue => returns all positions in queue + 1 (as if he would undelegate now)
-            await (await token.connect(delegator).approve(operator.address, parseEther("1000"))).wait()
-            await (await token.connect(delegator2).approve(operator.address, parseEther("1000"))).wait()
-            await (await token.connect(delegator3).approve(operator.address, parseEther("1000"))).wait()
-            await (await operator.connect(delegator).delegate(parseEther("1000"))).wait()
-            await (await operator.connect(delegator2).delegate(parseEther("1000"))).wait()
-            await (await operator.connect(delegator3).delegate(parseEther("1000"))).wait()
-            await (await operator.stake(sponsorship.address, parseEther("3000"))).wait()
-
-            await (await operator.connect(delegator).undelegate(parseEther("500"))).wait()
-            await (await operator.connect(delegator2).undelegate(parseEther("500"))).wait()
-
-            expect(await operator.queuePositionOf(delegator.address)).to.equal(1) // first in queue
-            expect(await operator.queuePositionOf(delegator2.address)).to.equal(2) // second in queue
-            expect(await operator.queuePositionOf(delegator3.address)).to.equal(3) // not in queue
-
-            // undelegate some more => move down into the queue
-            await (await operator.connect(delegator).undelegate(parseEther("500"))).wait()
-            await (await operator.connect(delegator2).undelegate(parseEther("500"))).wait()
-            expect(await operator.queuePositionOf(delegator.address)).to.equal(3) // first aand third in queue
-            expect(await operator.queuePositionOf(delegator2.address)).to.equal(4) // second and fourth in queue
-            expect(await operator.queuePositionOf(delegator3.address)).to.equal(5) // not in queue
-
-            await (await operator.connect(delegator3).undelegate(parseEther("500"))).wait()
-            expect(await operator.queuePositionOf(delegator3.address)).to.equal(5) // in queue (same position as before being in the queue)
-        })
-    })
-
     describe("Scenarios", (): void => {
 
         // https://hackmd.io/QFmCXi8oT_SMeQ111qe6LQ
@@ -436,6 +381,59 @@ describe("Operator contract", (): void => {
             await (await token.connect(delegator).approve(operator.address, parseEther("1000"))).wait()
             await expect(operator.connect(delegator).delegate(parseEther("1000")))
                 .to.emit(operator, "Delegated").withArgs(delegator.address, parseEther("1000"))
+        })
+
+        it("balanceInData returns 0 if delegator is not delegated or has 0 balance", async function(): Promise<void> {
+            const { token: dataToken } = sharedContracts
+            await setTokens(delegator, "1000")
+            const { operator } = await deployOperator(operatorWallet)
+            expect(await operator.connect(delegator).balanceInData(delegator.address)).to.equal(0)
+
+            await (await dataToken.connect(delegator).transferAndCall(operator.address, parseEther("1000"), "0x")).wait()
+            expect(await operator.connect(delegator).balanceInData(delegator.address)).to.equal(parseEther("1000"))
+
+            await (await operator.connect(delegator).undelegate(parseEther("1000"))).wait()
+            expect(await operator.connect(delegator).balanceInData(delegator.address)).to.equal(0)
+        })
+
+        it("returns the correct queue position for a delegator not in queue", async function(): Promise<void> {
+            const { token } = sharedContracts
+            await setTokens(delegator, "1000")
+            await setTokens(delegator2, "1000")
+            await setTokens(delegator3, "1000")
+            const { operator } = await deployOperator(operatorWallet)
+            const sponsorship  = await deploySponsorship(sharedContracts)
+
+            // delegator can query his position in the queue without delegating
+            expect(await operator.queuePositionOf(delegator.address)).to.equal(1) // not in queue
+
+            // all delegators delegate to operator
+            // delegator and delegator2 are in the queue => returns position in front of him + himself
+            // delegator3 is not in the queue => returns all positions in queue + 1 (as if he would undelegate now)
+            await (await token.connect(delegator).approve(operator.address, parseEther("1000"))).wait()
+            await (await token.connect(delegator2).approve(operator.address, parseEther("1000"))).wait()
+            await (await token.connect(delegator3).approve(operator.address, parseEther("1000"))).wait()
+            await (await operator.connect(delegator).delegate(parseEther("1000"))).wait()
+            await (await operator.connect(delegator2).delegate(parseEther("1000"))).wait()
+            await (await operator.connect(delegator3).delegate(parseEther("1000"))).wait()
+            await (await operator.stake(sponsorship.address, parseEther("3000"))).wait()
+
+            await (await operator.connect(delegator).undelegate(parseEther("500"))).wait()
+            await (await operator.connect(delegator2).undelegate(parseEther("500"))).wait()
+
+            expect(await operator.queuePositionOf(delegator.address)).to.equal(1) // first in queue
+            expect(await operator.queuePositionOf(delegator2.address)).to.equal(2) // second in queue
+            expect(await operator.queuePositionOf(delegator3.address)).to.equal(3) // not in queue
+
+            // undelegate some more => move down into the queue
+            await (await operator.connect(delegator).undelegate(parseEther("500"))).wait()
+            await (await operator.connect(delegator2).undelegate(parseEther("500"))).wait()
+            expect(await operator.queuePositionOf(delegator.address)).to.equal(3) // first aand third in queue
+            expect(await operator.queuePositionOf(delegator2.address)).to.equal(4) // second and fourth in queue
+            expect(await operator.queuePositionOf(delegator3.address)).to.equal(5) // not in queue
+
+            await (await operator.connect(delegator3).undelegate(parseEther("500"))).wait()
+            expect(await operator.queuePositionOf(delegator3.address)).to.equal(5) // in queue (same position as before being in the queue)
         })
 
         describe("DefaultDelegationPolicy / DefaltUndelegationPolicy", () => {

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Sponsorship.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Sponsorship.test.ts
@@ -246,6 +246,13 @@ describe("Sponsorship contract", (): void => {
                 .to.be.revertedWithCustomError(sponsorship, "LeavePenalty")
         })
 
+        it("won't let you reduceStake if you're not staked", async function(): Promise<void> {
+            await expect(defaultSponsorship.connect(operator).reduceStakeTo(0))
+                .to.be.revertedWithCustomError(defaultSponsorship, "CannotIncreaseStake")
+            await expect(defaultSponsorship.connect(operator).reduceStakeTo(parseEther("1")))
+                .to.be.revertedWithCustomError(defaultSponsorship, "CannotIncreaseStake")
+        })
+
         it("won't let you unstake if you're not staked", async function(): Promise<void> {
             await expect(defaultSponsorship.connect(operator).unstake())
                 .to.be.revertedWithCustomError(defaultSponsorship, "OperatorNotStaked")

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Sponsorship.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Sponsorship.test.ts
@@ -227,7 +227,7 @@ describe("Sponsorship contract", (): void => {
             await (await sponsorship.sponsor(parseEther("10000"))).wait()
             await (await token.connect(operator).transferAndCall(sponsorship.address, parseEther("100"), operator.address)).wait()
             await expect(sponsorship.connect(operator).reduceStakeTo(parseEther("50")))
-                .to.be.revertedWithCustomError(defaultSponsorship, "MinimumStake")
+                .to.be.revertedWithCustomError(sponsorship, "MinimumStake")
         })
 
         it("won't let increase stake with reduceStakeTo", async function(): Promise<void> {
@@ -235,7 +235,7 @@ describe("Sponsorship contract", (): void => {
             await (await sponsorship.sponsor(parseEther("10000"))).wait()
             await (await token.connect(operator).transferAndCall(sponsorship.address, parseEther("100"), operator.address)).wait()
             await expect(sponsorship.connect(operator).reduceStakeTo(parseEther("150")))
-                .to.be.revertedWithCustomError(defaultSponsorship, "CannotIncreaseStake")
+                .to.be.revertedWithCustomError(sponsorship, "CannotIncreaseStake")
         })
 
         it("won't let unstake if you would be slashed", async function(): Promise<void> {
@@ -243,12 +243,11 @@ describe("Sponsorship contract", (): void => {
             await (await sponsorship.sponsor(parseEther("10000"))).wait()
             await (await token.connect(operator).transferAndCall(sponsorship.address, parseEther("100"), operator.address)).wait()
             await expect(sponsorship.connect(operator).unstake())
-                .to.be.revertedWithCustomError(defaultSponsorship, "LeavePenalty")
+                .to.be.revertedWithCustomError(sponsorship, "LeavePenalty")
         })
 
         it("won't let you unstake if you're not staked", async function(): Promise<void> {
-            const sponsorship = await deploySponsorshipWithoutFactory(contracts)
-            await expect(sponsorship.connect(operator).unstake())
+            await expect(defaultSponsorship.connect(operator).unstake())
                 .to.be.revertedWithCustomError(defaultSponsorship, "OperatorNotStaked")
         })
 

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Sponsorship.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Sponsorship.test.ts
@@ -260,12 +260,12 @@ describe("Sponsorship contract", (): void => {
         })
 
         it("lets you unstake (without being slashed) within penalty period if unfunded", async function(): Promise<void> {
-            const blocktime = await getBlockTimestamp()
-            await advanceToTimestamp(blocktime + 1, "Sponsorship")
+            const start = await getBlockTimestamp()
+            await advanceToTimestamp(start + 1, "Sponsorship")
             const sponsorship = await deploySponsorshipWithoutFactory(contracts, { penaltyPeriodSeconds: 100 })
             await (await sponsorship.sponsor(parseEther("10"))).wait()
             await (await token.connect(operator).transferAndCall(sponsorship.address, parseEther("100"), operator.address)).wait()
-            await advanceToTimestamp(blocktime + 20)
+            await advanceToTimestamp(start + 20)
             await (await sponsorship.connect(operator).unstake()).wait()
         })
     })


### PR DESCRIPTION
* Move "toplevel-it"s under describe blocks in Operator test
* Use defaultSponsorship in Sponsorship test