### PR TITLE
ETH-636: Take fisherman's reward from self-delegation

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
@@ -405,7 +405,8 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
                 revert AccessDeniedOperatorOnly();
             }
         }
-        moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._forceUnstake.selector, sponsorship, maxQueuePayoutIterations));
+        moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._forceUnstake.selector, sponsorship));
+        payOutQueue(maxQueuePayoutIterations);
     }
 
     //////////////////////////////////////////////////////////////////////////////////

--- a/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
@@ -59,6 +59,10 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
     event NodesSet(address[] nodes);
     event MetadataUpdated(string metadataJsonString, address indexed operatorAddress, uint operatorsCutFraction); // = owner() of this contract
 
+    // when the operator gets slashed an amount in DATA, the corresponding amount of self-delegated operator tokens are burned (other delegators' DATA value won't change)
+    //   but only down to zero, after which the DATA losses are borne by all delegators via loss of operator DATA value without corresponding operator token burn
+    event OperatorSlashed(uint slashingAmountDataWei, uint slashingAmountInOperatorTokensWei, uint actuallySlashedInOperatorTokensWei);
+
     error AccessDeniedOperatorOnly();
     error AccessDeniedNodesOnly();
     error DelegationBelowMinimum();
@@ -183,7 +187,7 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
         ERC20Upgradeable.__ERC20_init(operatorTokenName, operatorTokenName);
 
         // DEFAULT_ADMIN_ROLE is needed (by factory) for setting modules and policies
-        _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
+        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
 
         // can't call updateMetadata because it has the onlyOperator guard
         metadata = operatorMetadataJson;
@@ -198,6 +202,14 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
 
     function _msgData() internal view virtual override(ContextUpgradeable, ERC2771ContextUpgradeable) returns (bytes calldata) {
         return super._msgData();
+    }
+
+    /**
+     * Trusted gasless meta-transaction forwarder, can set _msgSender() (where used instead of msg.sender)
+     * @dev see ERC-2771: Secure Protocol for Native Meta Transactions (https://eips.ethereum.org/EIPS/eip-2771)
+     **/
+    function isTrustedForwarder(address forwarder) public view override(ERC2771ContextUpgradeable) returns (bool) {
+        return streamrConfig.trustedForwarder() == forwarder;
     }
 
     function _transfer(address from, address to, uint amount) internal override {
@@ -250,10 +262,6 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
         return moduleGet(abi.encodeWithSelector(exchangeRatePolicy.operatorTokenToData.selector, balanceOf(delegator), address(exchangeRatePolicy)));
     }
 
-    function isTrustedForwarder(address forwarder) public view override(ERC2771ContextUpgradeable) returns (bool) {
-        return streamrConfig.trustedForwarder() == forwarder;
-    }
-
     function updateMetadata(string calldata metadataJsonString) external onlyOperator {
         metadata = metadataJsonString;
         emit MetadataUpdated(metadataJsonString, owner, operatorsCutFraction);
@@ -277,7 +285,7 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
      * If not, the token sender is the delegator
      */
     function onTokenTransfer(address sender, uint amount, bytes calldata data) external {
-        if (_msgSender() != address(token)) {
+        if (msg.sender != address(token)) {
             revert AccessDeniedDATATokenOnly();
         }
 
@@ -345,26 +353,27 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
     // Implementations found in StakeModule.sol
     /////////////////////////////////////////
 
+    /**
+     * Stake DATA tokens from this contract's DATA balance into Sponsorships.
+     * Can only happen if all the delegators who want to undelegate have been paid out first.
+     * This means the operator must clear the queue as part of normal operation before they can change staking allocations.
+     **/
     function stake(Sponsorship sponsorship, uint amountWei) external onlyOperator {
         moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._stake.selector, sponsorship, amountWei));
     }
+
+    /**
+     * Take out some of the stake from a sponsorship without completely unstaking
+     * Except if you call this with targetStakeWei == 0, then it will actually call unstake
+     **/
     function reduceStakeTo(Sponsorship sponsorship, uint targetStakeWei) external onlyOperator {
-        moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._reduceStakeTo.selector, sponsorship, targetStakeWei));
+        reduceStakeWithoutQueue(sponsorship, targetStakeWei);
+        payOutQueue(0);
     }
+
+    /** In case the queue is very long (e.g. due to spamming), give the operator an option to free funds from Sponsorships to pay out the queue in parts */
     function reduceStakeWithoutQueue(Sponsorship sponsorship, uint targetStakeWei) public onlyOperator {
-        moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._reduceStakeWithoutQueue.selector, sponsorship, targetStakeWei));
-    }
-    function unstakeWithoutQueue(Sponsorship sponsorship) public onlyOperator {
-        moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._unstakeWithoutQueue.selector, sponsorship));
-    }
-    function forceUnstake(Sponsorship sponsorship, uint maxQueuePayoutIterations) external {
-        // onlyOperator check happens only if grace period hasn't passed yet
-        if (block.timestamp < undelegationQueue[queueCurrentIndex].timestamp + streamrConfig.maxQueueSeconds() // solhint-disable-line not-rely-on-time
-            && !hasRole(CONTROLLER_ROLE, _msgSender()))
-        {
-            revert AccessDeniedOperatorOnly();
-        }
-        moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._forceUnstake.selector, sponsorship, maxQueuePayoutIterations));
+        moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._reduceStakeTo.selector, sponsorship, targetStakeWei));
     }
 
     /**
@@ -374,6 +383,29 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
     function unstake(Sponsorship sponsorship) public onlyOperator {
         unstakeWithoutQueue(sponsorship);
         payOutQueue(0);
+    }
+
+    /** In case the queue is very long (e.g. due to spamming), give the operator an option to free funds from Sponsorships to pay out the queue in parts */
+    function unstakeWithoutQueue(Sponsorship sponsorship) public onlyOperator {
+        moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._unstake.selector, sponsorship));
+    }
+
+    /**
+     * Self-service undelegation queue handling.
+     * If the operator hasn't been doing its job, and undelegationQueue hasn't been paid out,
+     *   anyone can come along and forceUnstake from a sponsorship to get the payouts rolling
+     * Operator can also call this, if they want to forfeit the stake locked to flagging in a sponsorship (normal unstake would revert for safety)
+     * @param sponsorship the funds (unstake) to pay out the queue
+     * @param maxQueuePayoutIterations how many queue items to pay out, see getMyQueuePosition()
+     */
+    function forceUnstake(Sponsorship sponsorship, uint maxQueuePayoutIterations) external {
+        // onlyOperator check happens only if grace period hasn't passed yet, after that anyone can call this
+        if (block.timestamp < undelegationQueue[queueCurrentIndex].timestamp + streamrConfig.maxQueueSeconds()) { // solhint-disable-line not-rely-on-time
+            if (!hasRole(CONTROLLER_ROLE, _msgSender())) {
+                revert AccessDeniedOperatorOnly();
+            }
+        }
+        moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._forceUnstake.selector, sponsorship, maxQueuePayoutIterations));
     }
 
     //////////////////////////////////////////////////////////////////////////////////
@@ -396,13 +428,44 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
         emit MetadataUpdated(metadata, _msgSender(), newOperatorsCutFraction);
     }
 
+    /**
+     * If the sum of accumulated earnings over all staked Sponsorships (includes operator's share of the earnings) becomes too large,
+     *   then anyone can call this method and point out a set of sponsorships where earnings together sum up to maxAllowedEarningsFraction.
+     * Caller gets fishermanRewardFraction of the operator's earnings share as a reward, if they provide that set of sponsorships.
+     */
     function withdrawEarningsFromSponsorships(Sponsorship[] memory sponsorshipAddresses) public {
-        // this is in stakeModule because it calls _handleProfit
-        moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._withdrawEarningsFromSponsorships.selector, sponsorshipAddresses));
+        uint valueBeforeWithdraw = valueWithoutEarnings();
+        uint withdrawnEarningsDataWei = withdrawEarningsFromSponsorshipsWithoutQueue(sponsorshipAddresses);
+
+        // if the caller is an outsider, and if sum of earnings are more than allowed, then send out the reward and slash operator
+        address msgSender = _msgSender();
+        if (!hasRole(CONTROLLER_ROLE, msgSender) && nodeIndex[msgSender] == 0) {
+            uint allowedDifference = valueBeforeWithdraw * streamrConfig.maxAllowedEarningsFraction() / 1 ether;
+            if (withdrawnEarningsDataWei > allowedDifference) {
+                uint rewardDataWei = withdrawnEarningsDataWei * streamrConfig.fishermanRewardFraction() / 1 ether;
+                _slashSelfDelegation(rewardDataWei);
+                token.transfer(msgSender, rewardDataWei);
+                emit OperatorValueUpdate(totalStakedIntoSponsorshipsWei - totalSlashedInSponsorshipsWei, token.balanceOf(address(this)));
+            }
+        }
+
+        payOutQueue(0);
     }
-    function withdrawEarningsFromSponsorshipsWithoutQueue(Sponsorship[] memory sponsorshipAddresses) public {
-        // this is in stakeModule because it calls _handleProfit
-        moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._withdrawEarningsFromSponsorshipsWithoutQueue.selector, sponsorshipAddresses, _msgSender()));
+
+    /** In case the queue is very long (e.g. due to spamming), give the operator an option to free funds from Sponsorships to pay out the queue in parts */
+    function withdrawEarningsFromSponsorshipsWithoutQueue(Sponsorship[] memory sponsorshipAddresses) public returns (uint withdrawnEarningsDataWei) {
+        return moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._withdrawEarnings.selector, sponsorshipAddresses));
+    }
+
+    /** Operator is slashed by burning their operator tokens */
+    function _slashSelfDelegation(uint amountDataWei) internal {
+        uint selfDelegation = balanceOf(owner);
+        if (selfDelegation == 0) { return; }
+        uint amountOperatorTokens = moduleCall(address(exchangeRatePolicy), abi.encodeWithSelector(exchangeRatePolicy.operatorTokenToDataInverse.selector, amountDataWei));
+        uint burnAmountWei = min(selfDelegation, amountOperatorTokens);
+        _burn(owner, burnAmountWei);
+        emit OperatorSlashed(amountDataWei, amountOperatorTokens, burnAmountWei);
+        emit BalanceUpdate(owner, balanceOf(owner), totalSupply());
     }
 
     /**
@@ -435,7 +498,6 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
         }
         maxAllowedEarnings = valueWithoutEarnings() * streamrConfig.maxAllowedEarningsFraction() / 1 ether;
     }
-
 
     ////////////////////////////////////////
     // NODE FUNCTIONS: HEARTBEAT, FLAGGING, AND VOTING
@@ -516,15 +578,12 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
     /////////////////////////////////////////
 
     function onSlash(uint amountSlashed) external {
-        Sponsorship sponsorship = Sponsorship(_msgSender());
+        Sponsorship sponsorship = Sponsorship(msg.sender);
         if (indexOfSponsorships[sponsorship] == 0) {
             revert NotMyStakedSponsorship();
         }
 
-        // operator pays for slashing by undelegating worth slashing
-        uint amountOperatorTokens = moduleCall(address(exchangeRatePolicy), abi.encodeWithSelector(exchangeRatePolicy.operatorTokenToDataInverse.selector, amountSlashed));
-        _burn(owner, min(balanceOf(owner), amountOperatorTokens));
-        emit BalanceUpdate(owner, balanceOf(owner), totalSupply());
+        _slashSelfDelegation(amountSlashed);
 
         // operator value is decreased by the slashed amount => exchange rate doesn't change (unless the operator ran out of tokens)
         slashedIn[sponsorship] += amountSlashed;
@@ -539,19 +598,18 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
     }
 
     function onKick(uint, uint receivedPayoutWei) external {
-        Sponsorship sponsorship = Sponsorship(_msgSender());
+        Sponsorship sponsorship = Sponsorship(msg.sender);
         if (indexOfSponsorships[sponsorship] == 0) {
             revert NotMyStakedSponsorship();
         }
-        // _removeSponsorship(sponsorship, receivedPayoutWei);
         moduleCall(address(stakeModule), abi.encodeWithSelector(stakeModule._removeSponsorship.selector, sponsorship, receivedPayoutWei));
     }
 
     function onReviewRequest(address targetOperator) external {
-        if (SponsorshipFactory(streamrConfig.sponsorshipFactory()).deploymentTimestamp(_msgSender()) == 0) {
+        if (SponsorshipFactory(streamrConfig.sponsorshipFactory()).deploymentTimestamp(msg.sender) == 0) {
             revert AccessDeniedStreamrSponsorshipOnly();
         }
-        Sponsorship sponsorship = Sponsorship(_msgSender());
+        Sponsorship sponsorship = Sponsorship(msg.sender);
         emit ReviewRequest(sponsorship, targetOperator, sponsorship.flagMetadataJson(targetOperator));
     }
 

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/IStakeModule.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/IStakeModule.sol
@@ -8,7 +8,7 @@ interface IStakeModule {
     function _stake(Sponsorship sponsorship, uint amountWei) external;
     function _reduceStakeTo(Sponsorship sponsorship, uint targetStakeWei) external;
     function _unstake(Sponsorship sponsorship) external;
-    function _forceUnstake(Sponsorship sponsorship, uint maxQueuePayoutIterations) external;
+    function _forceUnstake(Sponsorship sponsorship) external;
     function _removeSponsorship(Sponsorship sponsorship, uint receivedDuringUnstakingWei) external;
     function _withdrawEarnings(Sponsorship[] memory sponsorshipAddresses) external returns (uint sumEarnings);
 }

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/IStakeModule.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/IStakeModule.sol
@@ -7,10 +7,8 @@ import "../Sponsorship.sol";
 interface IStakeModule {
     function _stake(Sponsorship sponsorship, uint amountWei) external;
     function _reduceStakeTo(Sponsorship sponsorship, uint targetStakeWei) external;
-    function _reduceStakeWithoutQueue(Sponsorship sponsorship, uint targetStakeWei) external;
-    function _unstakeWithoutQueue(Sponsorship sponsorship) external;
+    function _unstake(Sponsorship sponsorship) external;
     function _forceUnstake(Sponsorship sponsorship, uint maxQueuePayoutIterations) external;
     function _removeSponsorship(Sponsorship sponsorship, uint receivedDuringUnstakingWei) external;
-    function _withdrawEarningsFromSponsorships(Sponsorship[] memory sponsorshipAddresses) external;
-    function _withdrawEarningsFromSponsorshipsWithoutQueue(Sponsorship[] memory sponsorshipAddresses, address msgSender) external;
+    function _withdrawEarnings(Sponsorship[] memory sponsorshipAddresses) external returns (uint sumEarnings);
 }

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/QueueModule.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/QueueModule.sol
@@ -98,7 +98,7 @@ contract QueueModule is IQueueModule, Operator {
      **/
     function _triggerAnotherOperatorWithdraw(address otherOperatorAddress, Sponsorship[] memory sponsorshipAddresses) public {
         uint balanceBeforeWei = token.balanceOf(address(this));
-        Operator(otherOperatorAddress).withdrawEarningsFromSponsorshipsWithoutQueue(sponsorshipAddresses);
+        Operator(otherOperatorAddress).withdrawEarningsFromSponsorships(sponsorshipAddresses);
         uint balanceAfterWei = token.balanceOf(address(this));
         uint earnings = balanceAfterWei - balanceBeforeWei;
         if (earnings == 0) {

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/StakeModule.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/StakeModule.sol
@@ -59,13 +59,11 @@ contract StakeModule is IStakeModule, Operator {
      *   anyone can come along and forceUnstake from a sponsorship to get the payouts rolling
      * Operator can also call this, if they want to forfeit the stake locked to flagging in a sponsorship (normal unstake would revert for safety)
      * @param sponsorship the funds (unstake) to pay out the queue
-     * @param maxQueuePayoutIterations how many queue items to pay out, see getMyQueuePosition()
      */
-    function _forceUnstake(Sponsorship sponsorship, uint maxQueuePayoutIterations) external {
+    function _forceUnstake(Sponsorship sponsorship) external {
         uint balanceBeforeWei = token.balanceOf(address(this));
         sponsorship.forceUnstake();
         _removeSponsorship(sponsorship, token.balanceOf(address(this)) - balanceBeforeWei);
-        payOutQueue(maxQueuePayoutIterations);
     }
 
     /**

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/StakeModule.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/StakeModule.sol
@@ -7,11 +7,8 @@ import "../StreamrConfig.sol";
 import "../Operator.sol";
 
 contract StakeModule is IStakeModule, Operator {
-    /**
-     * Stake DATA tokens from this contract's DATA balance into Sponsorships.
-     * Can only happen if all the delegators who want to undelegate have been paid out first.
-     * This means the operator must clear the queue as part of normal operation before they can change staking allocations.
-     **/
+
+    /** Stake DATA tokens from this contract's DATA balance into Sponsorships. */
     function _stake(Sponsorship sponsorship, uint amountWei) external {
         if(SponsorshipFactory(streamrConfig.sponsorshipFactory()).deploymentTimestamp(address(sponsorship)) == 0) {
             revert AccessDeniedStreamrSponsorshipOnly();
@@ -36,19 +33,10 @@ contract StakeModule is IStakeModule, Operator {
         emit StakeUpdate(sponsorship, stakedInto[sponsorship] - slashedIn[sponsorship]);
     }
 
-    /**
-     * Take out some of the stake from a sponsorship without completely unstaking
-     * Except if you call this with targetStakeWei == 0, then it will actually call unstake
-     **/
-    function _reduceStakeTo(Sponsorship sponsorship, uint targetStakeWei) external {
-        _reduceStakeWithoutQueue(sponsorship, targetStakeWei);
-        payOutQueue(0);
-    }
-
     /** In case the queue is very long (e.g. due to spamming), give the operator an option to free funds from Sponsorships to pay out the queue in parts */
-    function _reduceStakeWithoutQueue(Sponsorship sponsorship, uint targetStakeWei) public {
+    function _reduceStakeTo(Sponsorship sponsorship, uint targetStakeWei) public {
         if (targetStakeWei == 0) {
-            _unstakeWithoutQueue(sponsorship);
+            _unstake(sponsorship);
             return;
         }
         uint cashoutWei = sponsorship.reduceStakeTo(targetStakeWei);
@@ -59,7 +47,7 @@ contract StakeModule is IStakeModule, Operator {
     }
 
     /** In case the queue is very long (e.g. due to spamming), give the operator an option to free funds from Sponsorships to pay out the queue in parts */
-    function _unstakeWithoutQueue(Sponsorship sponsorship) public {
+    function _unstake(Sponsorship sponsorship) public {
         uint balanceBeforeWei = token.balanceOf(address(this));
         sponsorship.unstake();
         _removeSponsorship(sponsorship, token.balanceOf(address(this)) - balanceBeforeWei);
@@ -96,7 +84,7 @@ contract StakeModule is IStakeModule, Operator {
             emit OperatorValueUpdate(totalStakedIntoSponsorshipsWei - totalSlashedInSponsorshipsWei, token.balanceOf(address(this)));
         } else {
             uint profitDataWei = receivedDuringUnstakingWei - stakedInto[sponsorship];
-            _splitEarnings(profitDataWei, 0, address(0));
+            _splitEarnings(profitDataWei);
         }
 
         // remove from array: replace with the last element
@@ -117,6 +105,17 @@ contract StakeModule is IStakeModule, Operator {
         emit StakeUpdate(sponsorship, 0);
     }
 
+    /** @dev this is in stakeModule because it calls _splitEarnings */
+    function _withdrawEarnings(Sponsorship[] memory sponsorshipAddresses) public returns (uint sumEarnings) {
+        for (uint i = 0; i < sponsorshipAddresses.length; i++) {
+            sumEarnings += sponsorshipAddresses[i].withdraw(); // this contract receives DATA tokens
+        }
+        if (sumEarnings == 0) {
+            revert NoEarnings();
+        }
+        _splitEarnings(sumEarnings);
+    }
+
     /**
      * Whenever earnings from Sponsorships come in, split them as follows:
      *  1) to protocol: send out protocolFeeFraction * earnings as protocol fee, and then
@@ -125,64 +124,19 @@ contract StakeModule is IStakeModule, Operator {
      *                  paid in self-delegation (by minting operator tokens to Operator)
      * If the operator is penalized for too much earnings, a fraction will be deducted from the operator's cut and sent to operatorsCutSplitRecipient
      * @param earningsDataWei income to be processed, in DATA
-     * @param operatorsCutSplitFraction fraction of the operator's cut that is sent NOT to the operator but to the operatorsCutSplitRecipient
-     * @param operatorsCutSplitRecipient non-zero if the operator is penalized for too much earnings, otherwise `address(0)`
      **/
-    function _splitEarnings(uint earningsDataWei, uint operatorsCutSplitFraction, address operatorsCutSplitRecipient) public {
+    function _splitEarnings(uint earningsDataWei) public {
         uint protocolFee = earningsDataWei * streamrConfig.protocolFeeFraction() / 1 ether;
         token.transfer(streamrConfig.protocolFeeBeneficiary(), protocolFee);
-
-        uint operatorsCutDataWei = (earningsDataWei - protocolFee) * operatorsCutFraction / 1 ether;
-
-        uint operatorPenaltyDataWei = 0;
-        if (operatorsCutSplitFraction > 0) {
-            operatorPenaltyDataWei = operatorsCutDataWei * operatorsCutSplitFraction / 1 ether;
-            token.transfer(operatorsCutSplitRecipient, operatorPenaltyDataWei);
-        }
 
         // "self-delegate" the operator's share === mint new operator tokens
         // because _delegate is assumed to be called AFTER the DATA token transfer, the result of calling it is equivalent to:
         //  1) send operator's cut in DATA tokens to the operator (removed from DATA balance, NO burning of tokens)
         //  2) the operator delegates them back to the contract (added back to DATA balance, minting new tokens)
-        _delegate(owner, operatorsCutDataWei - operatorPenaltyDataWei);
+        uint operatorsCutDataWei = (earningsDataWei - protocolFee) * operatorsCutFraction / 1 ether;
+        _delegate(owner, operatorsCutDataWei);
 
         // the rest just goes to the Operator contract's DATA balance, inflating the Operator token value, and so is counted as Profit
-        emit Profit(earningsDataWei - protocolFee - operatorsCutDataWei, operatorsCutDataWei - operatorPenaltyDataWei, protocolFee);
-    }
-
-
-    /**
-     * If the sum of accumulated earnings over all staked Sponsorships (includes operator's share of the earnings) becomes too large,
-     *   then anyone can call this method and point out a set of sponsorships where earnings together sum up to maxAllowedEarningsFraction.
-     * Caller gets fishermanRewardFraction of the operator's earnings share as a reward, if they provide that set of sponsorships.
-     */
-    function _withdrawEarningsFromSponsorships(Sponsorship[] memory sponsorshipAddresses) public {
-        withdrawEarningsFromSponsorshipsWithoutQueue(sponsorshipAddresses);
-        payOutQueue(0);
-    }
-
-    /** In case the queue is very long (e.g. due to spamming), give the operator an option to free funds from Sponsorships to pay out the queue in parts */
-    function _withdrawEarningsFromSponsorshipsWithoutQueue(Sponsorship[] memory sponsorshipAddresses, address msgSender) public {
-        uint valueBeforeWithdraw = valueWithoutEarnings();
-
-        uint sumEarnings = 0;
-        for (uint i = 0; i < sponsorshipAddresses.length; i++) {
-            sumEarnings += sponsorshipAddresses[i].withdraw(); // this contract receives DATA tokens
-        }
-        if (sumEarnings == 0) {
-            revert NoEarnings();
-        }
-
-        // if the caller is an outsider, and if sum of earnings are more than allowed, then give part of the operator's cut to the caller as a reward
-        address penaltyRecipient = address(0);
-        uint penaltyFraction = 0;
-        if (!hasRole(CONTROLLER_ROLE, msgSender) && nodeIndex[msgSender] == 0) {
-            uint allowedDifference = valueBeforeWithdraw * streamrConfig.maxAllowedEarningsFraction() / 1 ether;
-            if (sumEarnings > allowedDifference) {
-                penaltyRecipient = msgSender;
-                penaltyFraction = streamrConfig.fishermanRewardFraction();
-            }
-        }
-        _splitEarnings(sumEarnings, penaltyFraction, penaltyRecipient);
+        emit Profit(earningsDataWei - protocolFee - operatorsCutDataWei, operatorsCutDataWei, protocolFee);
     }
 }

--- a/packages/network-contracts/contracts/OperatorTokenomics/StreamrConfig.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/StreamrConfig.sol
@@ -57,18 +57,17 @@ contract StreamrConfig is Initializable, UUPSUpgradeable, AccessControlUpgradeab
     /**
      * The real-time precise operator value (that includes earnings) can not be kept track of, since it would mean looping through all Sponsorships in each transaction.
      * However, if `withdrawEarningsFromSponsorships` is called often enough, the `valueWithoutEarnings` is a good approximation.
-     * If the the withdrawn earnings are more than `maxAllowedEarningsFraction * valueWithoutEarnings`,
-     *   then `fishermanRewardFraction` of the operator's cut is sent to the `withdrawEarningsFromSponsorships` caller, which can be anyone.
-     * This means operator should call `withdrawEarningsFromSponsorships` often enough to not accumulate too much earnings, so they can keep all of the cut.
+     * If the withdrawn earnings are more than `maxAllowedEarningsFraction * valueWithoutEarnings`,
+     *   then `fishermanRewardFraction` is the fraction of the withdrawn earnings that is un-selfdelegated (burned) from the operator and sent to the fisherman
+     * This means operator should call `withdrawEarningsFromSponsorships` often enough to not accumulate too much earnings.
      * Fraction means this value is between 0.0 ~ 1.0, expressed as multiple of 1e18, like ETH or tokens.
      */
     uint public maxAllowedEarningsFraction;
 
     /**
-     * If the the withdrawn earnings are more than `maxAllowedEarningsFraction * valueWithoutEarnings`,
-     *   then `fishermanRewardFraction` is the fraction of the operator's cut that is sent out to the caller.
-     * E.g. if `fishermanRewardFraction = 0.5`, and the operator's cut of the incoming earnings are 100 DATA, and if the penalty is applied,
-     *   then the operator only receives 50 DATA, and whoever called the `withdrawEarningsFromSponsorships` will receive 50 DATA.
+     * If the withdrawn earnings are more than `maxAllowedEarningsFraction * valueWithoutEarnings`,
+     *   then `fishermanRewardFraction` is the fraction of the withdrawn earnings that is un-selfdelegated (burned) from the operator and sent to the fisherman
+     * E.g. if `fishermanRewardFraction = 0.1`, and the incoming earnings are 100 DATA, then whoever called the `withdrawEarningsFromSponsorships` will receive 10 DATA.
      * Fraction means this value is between 0.0 ~ 1.0, expressed as multiple of 1e18, like ETH or tokens.
      */
     uint public fishermanRewardFraction;
@@ -154,8 +153,8 @@ contract StreamrConfig is Initializable, UUPSUpgradeable, AccessControlUpgradeab
         setMaxQueueSeconds(30 days);
 
         // Withdraw incentivization
-        setMaxAllowedEarningsFraction(0.05 ether); // 5% of valueWithoutEarnings is when fisherman can poach part of the operator's cut
-        setFishermanRewardFraction(0.5 ether); // 50% of operator's cut goes to fisherman
+        setMaxAllowedEarningsFraction(0.05 ether); // 5% of valueWithoutEarnings is when fisherman gets rewarded from the operator's self-delegation
+        setFishermanRewardFraction(0.1 ether); // 10% of withdrawn earnings
 
         // protocol fee
         setProtocolFeeFraction(0.05 ether); // 5% of earnings go to protocol fee

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
@@ -504,9 +504,9 @@ describe("Operator contract", (): void => {
                 const { token } = sharedContracts
                 const { operator } = await deployOperator(operatorWallet, { overrideDelegationPolicy: hardhatEthers.constants.AddressZero })
                 await (await token.connect(operatorWallet).transferAndCall(operator.address, parseEther("1000"), "0x")).wait()
-                
+
                 await (await operator.connect(operatorWallet).transfer(delegator.address, parseEther("400"))).wait()
-                
+
                 expect(await operator.balanceOf(operatorWallet.address)).to.equal(parseEther("600"))
                 expect(await operator.balanceOf(delegator.address)).to.equal(parseEther("400"))
             })
@@ -515,9 +515,9 @@ describe("Operator contract", (): void => {
                 const { token } = sharedContracts
                 const { operator } = await deployOperator(operatorWallet, { overrideUndelegationPolicy: hardhatEthers.constants.AddressZero })
                 await (await token.connect(operatorWallet).transferAndCall(operator.address, parseEther("1000"), "0x")).wait()
-                
+
                 await (await operator.connect(operatorWallet).transfer(delegator.address, parseEther("400"))).wait()
-                
+
                 expect(await operator.balanceOf(operatorWallet.address)).to.equal(parseEther("600"))
                 expect(await operator.balanceOf(delegator.address)).to.equal(parseEther("400"))
             })
@@ -832,7 +832,7 @@ describe("Operator contract", (): void => {
             expect(formatEther(await operator.balanceOf(operatorWallet.address))).to.equal("168.840579710144927536") // TODO: find nice numbers!
         })
 
-        it("pays part of operator's cut from withdraw to caller if too much earnings", async function(): Promise<void> {
+        it("rewards fisherman and slashes operator if too much earnings withdrawn", async function(): Promise<void> {
             const { operator, contracts } = await deployOperator(operatorWallet, { operatorsCutPercent: 40 })
             const operator2 = await deployOperatorContract(contracts, operator2Wallet) // operator's cut doesn't affect calculations
             const sponsorship1 = await deploySponsorship(contracts)
@@ -890,28 +890,29 @@ describe("Operator contract", (): void => {
             //  protocol fee 5% = 100
             //  operator's cut 40% of the remaining 1900 = 760
             //  the remaining 1900 - 760 = 1140 will be shared among delegators (Profit)
-            //  reward will be 50% of the operator's cut = 380
-            //  the remaining 50% of the operator's cut = 380 will be added to operator1's self-delegation
-            // operator1's pool value increased by 1900 (earnings after protocol fee) - 380 (reward) = 1520
+            //  operator1 pool value after profit is 2000 + 1140 = 3140
+            //  operator's cut is self-delegated, exchange rate is 3140 / 2000 = 1.57 DATA / operator token
+            //    760 DATA / 1.57 ~= 483.44 operator tokens
+            //  fisherman's reward will be 10% of the earnings = 200 DATA, burned from self-delegation, keeping exchange rate at 1.57
+            const burnAmount = parseEther("200").mul(2000).div(3140) // ~= 127.38 operator tokens
             await expect(operator2.triggerAnotherOperatorWithdraw(operator.address, [sponsorship1.address, sponsorship2.address]))
-                .to.emit(operator, "Profit").withArgs(parseEther("1140"), parseEther("380"), parseEther("100"))
-                .to.emit(operator, "OperatorValueUpdate").withArgs(parseEther("2000"), parseEther("1520"))
-                .to.emit(operator2, "OperatorValueUpdate").withArgs(0, parseEther("1380")) // 0 == not staked anywhere
-
-            // operator1 pool value after profit is 2000 + 1140 = 3140 => exchange rate for operator's cut is 3140 / 2000 = 1.57 DATA / operator token
-            // operator2 pool value was 1000 DATA => exchange rate for operator's reward is 1000 / 1000 = 1 DATA / operator token
-            expect(await operator.valueWithoutEarnings()).to.equal(parseEther("3520"))
-            expect(await operator2.valueWithoutEarnings()).to.equal(parseEther("1380"))
+                .to.emit(operator, "Profit").withArgs(parseEther("1140"), parseEther("760"), parseEther("100"))
+                .to.emit(operator, "OperatorSlashed").withArgs(parseEther("200"), burnAmount, burnAmount)
+                .to.emit(operator, "OperatorValueUpdate").withArgs(parseEther("2000"), parseEther("1700"))
+                .to.emit(operator2, "OperatorValueUpdate").withArgs(0, parseEther("1200")) // 0 == not staked anywhere
+            expect(await operator.valueWithoutEarnings()).to.equal(parseEther("3700"))
+            expect(await operator2.valueWithoutEarnings()).to.equal(parseEther("1200"))
 
             // operator1's 380 DATA was added to operator1 pool value as self-delegation (not Profit)
-            //  => operatorWallet1 received 380 / 1.57 ~= 242.03 operator tokens, in addition to the 1000 from the initial self-delegation
-            // operator2's 380 DATA was added to operator2 pool value as self-delegation, exchange rate was still 1 DATA / operator token
-            //  => operatorWallet2 received 380 / 1 = 380 operator tokens, in addition to the 1000 operator tokens from the initial self-delegation
-            expect(await operator.balanceOf(operatorWallet.address)).to.equal("1242038216560509554140") // TODO: find nicer numbers!
-            expect(await operator2.balanceOf(operator2Wallet.address)).to.equal(parseEther("1380"))
+            //  => operatorWallet1 received 560 / 1.57 ~= 356.68 operator tokens, in addition to the 1000 from the initial self-delegation
+            expect(formatEther(await operator.balanceOf(operatorWallet.address)).slice(0, 7)).to.equal("1356.68")
+            // operator2's 200 DATA was added to operator2 pool value as self-delegation, exchange rate was still 1 DATA / operator token
+            //  => operatorWallet2 received 200 / 1 = 200 operator tokens, in addition to the 1000 operator tokens from the initial self-delegation
+            expect(formatEther(await operator2.balanceOf(operator2Wallet.address))).to.equal("1200.0")
 
-            // (other) delegators' balances are unchanged
-            expect(await operator.balanceOf(delegator.address)).to.equal(parseEther("1000"))
+            // (other) delegators' balances are unchanged, and exchange rate is still at 1.57
+            expect(formatEther(await operator.balanceOf(delegator.address))).to.equal("1000.0")
+            expect(formatEther(await operator.balanceInData(delegator.address))).to.equal("1569.999999999999999999")
         })
 
         it("can update operator cut fraction for himself, but NOT for others", async function(): Promise<void> {


### PR DESCRIPTION
Hopefully the last feature to get in...

self-delegation is slashed by burning the corresponding amount of operator tokens. So in net, the operator still makes (fee% - reward%) of the earnings. Which I guess is fair. Like with slashing in sponsorships, if the operator has a fee lower than the `fishermanRewardFraction` and managed to get slashed a lot, down to zero, then the fisherman's reward will be on the delegators.

Also other cleanups:
* reverted to msg.sender where appropriate (still left onlyNodes to use _msgSender even though that 100xs the price of heartbeats probably...)
* reverted some stuff from stake module to main contract. StakeModule size went down by a little at the cost of slightly larger Operator contract (note that StakeModule contains the Operator!)
* added comments, moved some of them back to main contract (just in case someone generates docs from the Operator.sol source...)