### PR TITLE
Final touch-ups of tokenomics contracts

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
@@ -496,11 +496,7 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
         return super._msgData();
     }
 
-    /*
-     * Override openzeppelin's ERC2771ContextUpgradeable function
-     * @dev isTrustedForwarder override and project registry role access adds trusted forwarder reset functionality
-     */
-    function isTrustedForwarder(address forwarder) public view override returns (bool) {
+    function isTrustedForwarder(address forwarder) public view override(ERC2771ContextUpgradeable) returns (bool) {
         return streamrConfig.trustedForwarder() == forwarder;
     }
 


### PR DESCRIPTION
refactor: moving functions around

so that Operator and Sponsorship would be a bit more consistent