### PR TITLE
ETH-652: check minimum delegation limit when someone delegates

### DIFF
--- a/packages/hub-contracts/.solhint.json
+++ b/packages/hub-contracts/.solhint.json
@@ -15,6 +15,7 @@
                 "maxLength": 50
             }
         ],
+        "no-global-import": "off",
         "constructor-syntax": "error",
         "const-name-snakecase": "error",
         "event-name-camelcase": "error",

--- a/packages/network-contracts/.solhint.json
+++ b/packages/network-contracts/.solhint.json
@@ -2,13 +2,14 @@
     "extends": "solhint:recommended",
     "plugins": [],
     "rules": {
+        "max-states-count": "off",
         "code-complexity": [
             "warn",
             11
         ],
         "function-max-lines": [
             "warn",
-            70
+            100
         ],
         "no-empty-blocks": "off",
         "no-unused-vars": "error",
@@ -19,6 +20,7 @@
                 "maxLength": 32
             }
         ],
+        "no-global-import": "off",
         "constructor-syntax": "error",
         "const-name-snakecase": "error",
         "event-name-camelcase": "error",

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/QueueModule.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/QueueModule.sol
@@ -106,5 +106,6 @@ contract QueueModule is IQueueModule, Operator {
         }
         // new DATA tokens are still unaccounted, will go to self-delegation instead of Profit
         _mintOperatorTokensWorth(owner, earnings);
+        emit OperatorValueUpdate(totalStakedIntoSponsorshipsWei - totalSlashedInSponsorshipsWei, token.balanceOf(address(this)));
     }
 }

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/QueueModule.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/QueueModule.sol
@@ -105,6 +105,6 @@ contract QueueModule is IQueueModule, Operator {
             revert DidNotReceiveReward();
         }
         // new DATA tokens are still unaccounted, will go to self-delegation instead of Profit
-        _delegate(owner, earnings);
+        _mintOperatorTokensWorth(owner, earnings);
     }
 }

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/StakeModule.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/StakeModule.sol
@@ -132,7 +132,7 @@ contract StakeModule is IStakeModule, Operator {
         //  1) send operator's cut in DATA tokens to the operator (removed from DATA balance, NO burning of tokens)
         //  2) the operator delegates them back to the contract (added back to DATA balance, minting new tokens)
         uint operatorsCutDataWei = (earningsDataWei - protocolFee) * operatorsCutFraction / 1 ether;
-        _delegate(owner, operatorsCutDataWei);
+        _mintOperatorTokensWorth(owner, operatorsCutDataWei);
 
         // the rest just goes to the Operator contract's DATA balance, inflating the Operator token value, and so is counted as Profit
         emit Profit(earningsDataWei - protocolFee - operatorsCutDataWei, operatorsCutDataWei, protocolFee);

--- a/packages/network-contracts/contracts/OperatorTokenomics/SponsorshipPolicies/AdminKickPolicy.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/SponsorshipPolicies/AdminKickPolicy.sol
@@ -12,7 +12,7 @@ contract AdminKickPolicy is IKickPolicy, Sponsorship {
 
     function localData() internal view returns(LocalStorage storage data) {
         bytes32 storagePosition = keccak256(abi.encodePacked("sponsorship.storage.AdminKickPolicy", address(this)));
-        assembly {data.slot := storagePosition}
+        assembly {data.slot := storagePosition} // solhint-disable-line no-inline-assembly
     }
 
     function setParam(uint adminAdress) external {

--- a/packages/network-contracts/contracts/OperatorTokenomics/testcontracts/TestExchangeRatePolicy.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/testcontracts/TestExchangeRatePolicy.sol
@@ -19,7 +19,7 @@ contract TestExchangeRatePolicy is IExchangeRatePolicy {
 
     function operatorTokenToDataInverse(uint) external view returns (uint) {}
 
-    function dataToOperatorToken(uint, uint) external view returns (uint) {
-        return 100;
+    function dataToOperatorToken(uint dataWei, uint) external view returns (uint) {
+        return dataWei;
     }
 }

--- a/packages/network-contracts/contracts/OperatorTokenomics/testcontracts/TestExchangeRatePolicy3.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/testcontracts/TestExchangeRatePolicy3.sol
@@ -18,7 +18,7 @@ contract TestExchangeRatePolicy3 is IExchangeRatePolicy {
 
     function operatorTokenToDataInverse(uint dataWei) external view returns (uint) {}
 
-    function dataToOperatorToken(uint dataWei, uint) external view returns (uint) {
+    function dataToOperatorToken(uint, uint) external view returns (uint) {
         // solhint-disable-next-line reason-string
         require(false); // using delegatecall the (success, data) returned values will be (0, 0)
     }

--- a/packages/network-contracts/contracts/OperatorTokenomics/testcontracts/TestExchangeRatePolicy3.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/testcontracts/TestExchangeRatePolicy3.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 
 import "../OperatorPolicies/IExchangeRatePolicy.sol";
 
-contract TestExchangeRatePolicy2 is IExchangeRatePolicy {
+contract TestExchangeRatePolicy3 is IExchangeRatePolicy {
 
     function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
         return interfaceId == type(IExchangeRatePolicy).interfaceId;
@@ -12,13 +12,14 @@ contract TestExchangeRatePolicy2 is IExchangeRatePolicy {
 
     function setParam(uint) external {}
 
-    function operatorTokenToData(uint) external view returns (uint) {
-        require(false, "revertedWithStringReason"); // using delegatecall the (success, data) returned values will be (0, 100)
+    function operatorTokenToData(uint tokenWei) external view returns (uint) {
+        return tokenWei;
     }
 
     function operatorTokenToDataInverse(uint dataWei) external view returns (uint) {}
 
     function dataToOperatorToken(uint dataWei, uint) external view returns (uint) {
-        return dataWei;
+        // solhint-disable-next-line reason-string
+        require(false); // using delegatecall the (success, data) returned values will be (0, 0)
     }
 }

--- a/packages/network-contracts/selectors.txt
+++ b/packages/network-contracts/selectors.txt
@@ -342,7 +342,7 @@ Error signatures:
 9e39d8be: AccessDeniedNodesOnly()
 69d9c224: AccessDeniedOperatorOnly()
 b3d3f77e: AccessDeniedStreamrSponsorshipOnly()
-ddecb772: DelegationBelowMinimum()
+24c69407: DelegationBelowMinimum(uint256,uint256)
 b1c5c787: DidNotReceiveReward()
 ec6c87a6: FirstEmptyQueueThenStake()
 918623b7: ModuleCallError(address,bytes)

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
@@ -36,6 +36,7 @@ describe("Operator contract", (): void => {
     let testKickPolicy: IKickPolicy
     let testExchangeRatePolicy: IExchangeRatePolicy
     let testExchangeRatePolicy2: IExchangeRatePolicy
+    let testExchangeRatePolicy3: IExchangeRatePolicy
 
     // burn all tokens then mint the corrent amount of new ones
     async function setTokens(account: Wallet, amount: string) {
@@ -57,7 +58,11 @@ describe("Operator contract", (): void => {
         }
 
         const operatorsCutFraction = parseEther("1").mul(opts?.operatorsCutPercent ?? 0).div(100)
-        await (await contracts.operatorFactory.addTrustedPolicies([ testExchangeRatePolicy.address, testExchangeRatePolicy2.address])).wait()
+        await (await contracts.operatorFactory.addTrustedPolicies([
+            testExchangeRatePolicy.address,
+            testExchangeRatePolicy2.address,
+            testExchangeRatePolicy3.address,
+        ])).wait()
         const operator = await deployOperatorContract(contracts, deployer, operatorsCutFraction, opts)
         return { operator, contracts }
     }
@@ -79,6 +84,7 @@ describe("Operator contract", (): void => {
 
         testExchangeRatePolicy = await (await getContractFactory("TestExchangeRatePolicy", admin)).deploy() as IExchangeRatePolicy
         testExchangeRatePolicy2 = await (await getContractFactory("TestExchangeRatePolicy2", admin)).deploy() as IExchangeRatePolicy
+        testExchangeRatePolicy3 = await (await getContractFactory("TestExchangeRatePolicy3", admin)).deploy() as IExchangeRatePolicy
 
         await (await sharedContracts.streamrConfig.setMinimumSelfDelegationFraction("0")).wait()
         await (await sharedContracts.streamrConfig.setProtocolFeeBeneficiary(protocolFeeBeneficiary.address)).wait()
@@ -88,8 +94,8 @@ describe("Operator contract", (): void => {
 
         // revert to initial test values (using the real values would break the majority of tests)
         const { streamrConfig } = sharedContracts
-        await( await streamrConfig.setFlagReviewerRewardWei(parseEther("1"))).wait()
-        await( await streamrConfig.setFlaggerRewardWei(parseEther("1"))).wait()
+        await (await streamrConfig.setFlagReviewerRewardWei(parseEther("1"))).wait()
+        await (await streamrConfig.setFlaggerRewardWei(parseEther("1"))).wait()
     })
 
     describe("Scenarios", (): void => {
@@ -175,12 +181,14 @@ describe("Operator contract", (): void => {
         // https://hackmd.io/Tmrj2OPLQwerMQCs_6yvMg
         it("forced example scenario", async function(): Promise<void> {
             const { token } = sharedContracts
+            setTokens(operatorWallet, "100")
             setTokens(delegator, "100")
             setTokens(delegator2, "100")
             setTokens(delegator3, "100")
 
             const days = 24 * 60 * 60
             const { operator } = await deployOperator(operatorWallet)
+            await (await token.connect(operatorWallet).transferAndCall(operator.address, parseEther("100"), "0x")).wait()
             await (await token.connect(delegator).transferAndCall(operator.address, parseEther("100"), "0x")).wait()
             await (await token.connect(delegator2).transferAndCall(operator.address, parseEther("100"), "0x")).wait()
             await (await token.connect(delegator3).transferAndCall(operator.address, parseEther("100"), "0x")).wait()
@@ -188,11 +196,12 @@ describe("Operator contract", (): void => {
             const sponsorship1 = await deploySponsorship(sharedContracts)
             const sponsorship2 = await deploySponsorship(sharedContracts)
             await operator.stake(sponsorship1.address, parseEther("200"))
-            await operator.stake(sponsorship2.address, parseEther("100"))
+            await operator.stake(sponsorship2.address, parseEther("200"))
 
             const timeAtStart = await getBlockTimestamp()
 
             // Starting state
+            expect(await operator.balanceOf(operatorWallet.address)).to.equal(parseEther("100"))
             expect(await operator.balanceOf(delegator.address)).to.equal(parseEther("100"))
             expect(await operator.balanceOf(delegator2.address)).to.equal(parseEther("100"))
             expect(await operator.balanceOf(delegator3.address)).to.equal(parseEther("100"))
@@ -209,13 +218,17 @@ describe("Operator contract", (): void => {
             await expect(operator.connect(delegator).forceUnstake(sponsorship1.address, 100))
                 .to.be.revertedWithCustomError(operator, "AccessDeniedOperatorOnly")
 
-            await advanceToTimestamp(timeAtStart + 31*days, "Operator unstakes 5 data from sponsorship1")
+            await advanceToTimestamp(timeAtStart + 31*days, "Operator unstakes 50 data from sponsorship1")
             await operator.reduceStakeTo(sponsorship1.address, parseEther("150"))
 
-            // sponsorship1 has 15 stake left, sponsorship2 has 10 stake left
+            // The first delegator got part of their DATA back
             expect(await operator.balanceOf(delegator.address)).to.equal(parseEther("50"))
+            expect(await sponsorship1.stakedWei(operator.address)).to.equal(parseEther("150"))
+            expect(await sponsorship2.stakedWei(operator.address)).to.equal(parseEther("200"))
+            expect(await token.balanceOf(operator.address)).to.equal(parseEther("0"))
 
             // now anyone can trigger the unstake and payout of the queue
+            // i.e. partial payment doesn't reset the queueing time ;)
             await expect(operator.connect(delegator2).forceUnstake(sponsorship1.address, 10))
                 .to.emit(operator, "Unstaked").withArgs(sponsorship1.address)
 
@@ -620,7 +633,7 @@ describe("Operator contract", (): void => {
                 .to.emit(contracts.operatorFactory, "OperatorLivenessChanged").withArgs(operator.address, true)
             expect(await operator.totalStakedIntoSponsorshipsWei()).to.equal(parseEther("1000"))
 
-            await expect(operator.reduceStakeWithoutQueue(sponsorship.address, 0))
+            await expect(operator.reduceStakeTo(sponsorship.address, 0))
                 .to.emit(contracts.operatorFactory, "OperatorLivenessChanged").withArgs(operator.address, false)
             expect(await operator.totalStakedIntoSponsorshipsWei()).to.equal(0)
         })
@@ -1817,7 +1830,7 @@ describe("Operator contract", (): void => {
                 .to.be.reverted
         })
 
-        it("moduleGet reverts for broken yield policies", async function(): Promise<void> {
+        it("moduleGet reverts for broken yield policies (without reason string)", async function(): Promise<void> {
             const { token: dataToken } = sharedContracts
             await setTokens(delegator, "1000")
             const { operator } = await deployOperator(operatorWallet, { overrideExchangeRatePolicy: testExchangeRatePolicy.address })
@@ -1826,21 +1839,20 @@ describe("Operator contract", (): void => {
                 .to.be.revertedWithCustomError(operator, "ModuleGetError") // delegatecall returns (0, 0)
         })
 
-        it("moduleGet reverts for broken yield policies 2", async function(): Promise<void> {
+        it("moduleGet reverts for broken yield policies (with reason string)", async function(): Promise<void> {
             const { token: dataToken } = sharedContracts
             await setTokens(delegator, "1000")
             const { operator } = await deployOperator(operatorWallet, { overrideExchangeRatePolicy: testExchangeRatePolicy2.address })
             await (await dataToken.connect(delegator).transferAndCall(operator.address, parseEther("1000"), "0x")).wait()
             await expect(operator.connect(delegator).balanceInData(delegator.address))
-                .to.be.reverted // delegatecall returns (0, data)
+                .to.be.revertedWith("revertedWithStringReason")
         })
 
         it("moduleCall reverts for broken exchange rate policy", async function(): Promise<void> {
             const { token: dataToken } = sharedContracts
             await setTokens(delegator, "1000")
-            const { operator } = await deployOperator(operatorWallet, { overrideExchangeRatePolicy: testExchangeRatePolicy.address })
-            await (await dataToken.connect(delegator).transferAndCall(operator.address, parseEther("1000"), "0x")).wait()
-            await expect(operator.connect(delegator).undelegate(parseEther("1000")))
+            const { operator } = await deployOperator(operatorWallet, { overrideExchangeRatePolicy: testExchangeRatePolicy3.address })
+            await expect(dataToken.connect(delegator).transferAndCall(operator.address, parseEther("1000"), "0x"))
                 .to.be.revertedWithCustomError(operator, "ModuleCallError") // delegatecall returns (0, 0)
         })
     })

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/OperatorContractOnlyJoinPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/OperatorContractOnlyJoinPolicy.test.ts
@@ -39,6 +39,7 @@ describe("OperatorContractOnlyJoinPolicy", (): void => {
         const badOp = await (await (await getContractFactory("Operator", operator)).deploy()).deployed() as Operator
         await (await badOp.initialize(token.address, streamrConfig.address, operator.address, "testpool", "{}", "1",
             [contracts.nodeModule.address, contracts.queueModule.address, contracts.stakeModule.address])).wait()
+        await (await badOp.setExchangeRatePolicy(contracts.defaultExchangeRatePolicy.address, "0")).wait()
         await (await token.connect(operator).transferAndCall(badOp.address, parseEther("5000"), "0x")).wait()
         await expect(badOp.stake(sponsorship.address, parseEther("5000")))
             .to.be.revertedWith("error_onlyOperators")


### PR DESCRIPTION
separate "delegating" from "minting operator tokens". They just aren't the same thing after all: "adding to self-delegation" only concerns the operator and mostly doesn't benefit from the minimum delegation check (or other checks for that matter).