### PR TITLE
fix StakeUpdate and SponsorshipUpdate events

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
@@ -286,7 +286,6 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
             try IOperator(operator).onSlash(actualSlashingWei) {} catch {}
         }
         emit OperatorSlashed(operator, actualSlashingWei);
-        emit StakeUpdate(operator, stakedWei[operator], getEarnings(operator), lockedStakeWei[operator]);
     }
 
     /**
@@ -358,8 +357,8 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
 
         payoutWei = _withdraw(operator);
         if (payoutWei > 0) {
-            emit StakeUpdate(operator, stakedWei[operator], 0, lockedStakeWei[operator]); // earnings will be zero after withdraw (see test)
-            emit SponsorshipUpdate(totalStakedWei, remainingWei, uint32(operatorCount), isRunning());
+            // earnings will be zero after withdraw (see test)
+            emit StakeUpdate(operator, stakedWei[operator], 0, lockedStakeWei[operator]);
         }
     }
 

--- a/packages/network-contracts/contracts/OperatorTokenomics/SponsorshipPolicies/VoteKickPolicy.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/SponsorshipPolicies/VoteKickPolicy.sol
@@ -247,6 +247,7 @@ contract VoteKickPolicy is IKickPolicy, Sponsorship {
         if (!flaggerIsGone) {
             emit StakeUpdate(flagger, stakedWei[flagger], getEarnings(flagger), lockedStakeWei[flagger]);
         }
+        emit SponsorshipUpdate(totalStakedWei, remainingWei, uint32(operatorCount), isRunning());
 
         delete flaggerAddress[target];
         delete voteStartTimestamp[target];


### PR DESCRIPTION
instead of sending StakeUpdate in _slash, make sure all callers (_removeOperator for kick and forceUnstake, _endVote for vote-kick) send both StakeUpdate and SponsorshipUpdate, to avoid multiple emits

SponsorshipUpdate isn't needed in withdraw