### PR TITLE
OperatorValueUpdate fixes

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/QueueModule.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/QueueModule.sol
@@ -98,7 +98,7 @@ contract QueueModule is IQueueModule, Operator {
      **/
     function _triggerAnotherOperatorWithdraw(address otherOperatorAddress, Sponsorship[] memory sponsorshipAddresses) public {
         uint balanceBeforeWei = token.balanceOf(address(this));
-        Operator(otherOperatorAddress).withdrawEarningsFromSponsorshipsWithoutQueue(sponsorshipAddresses);
+        Operator(otherOperatorAddress).withdrawEarningsFromSponsorships(sponsorshipAddresses);
         uint balanceAfterWei = token.balanceOf(address(this));
         uint earnings = balanceAfterWei - balanceBeforeWei;
         if (earnings == 0) {


### PR DESCRIPTION
fix: OperatorValueUpdate should happen after withdraw

...and only once after removeSponsorship; nowadays _splitEarnings doesn't call it.

<strike>Fisherman also doesn't need to service the queue (it used to be like that before a recent change)</strike>

also lots of comments!