### PR TITLE
ETH-654: fix very large amount of queued undelegation

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/QueueModule.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/QueueModule.sol
@@ -48,7 +48,7 @@ contract QueueModule is IQueueModule, Operator {
         }
 
         address delegator = undelegationQueue[queueCurrentIndex].delegator;
-        uint amountDataWei = undelegationQueue[queueCurrentIndex].amountWei;
+        uint amountDataWei = min(undelegationQueue[queueCurrentIndex].amountWei, valueWithoutEarnings());
 
         // Silently cap the undelegation to the amount of operator tokens the exiting delegator has,
         //   this means it's ok to add infinity tokens to undelegation queue, it means "undelegate all my tokens".

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
@@ -1477,6 +1477,17 @@ describe("Operator contract", (): void => {
             expect(formatEther(contractBalanceAfterDelegate)).to.equal("100.5")
             expect(formatEther(contractBalanceAfterUndelegate)).to.equal("0.0")
         })
+
+        it("undelegate completely if the amount is max uint256", async function(): Promise<void> {
+            const { token } = sharedContracts
+            await setTokens(delegator, "100")
+            const { operator } = await deployOperator(operatorWallet)
+            
+            await (await token.connect(delegator).transferAndCall(operator.address, parseEther("100"), "0x")).wait()
+
+            await expect(operator.connect(delegator).undelegate(hardhatEthers.constants.MaxUint256))
+                .to.emit(operator, "Undelegated").withArgs(delegator.address, parseEther("100"))
+        })
     })
 
     describe("Kick/slash handler", () => {


### PR DESCRIPTION
we should support queuing for type(uint).max, and it should just take all tokens