### PR TITLE
ETH-666: added missing access checks to onTokenTransfer

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/IERC677Receiver.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/IERC677Receiver.sol
@@ -3,5 +3,6 @@
 pragma solidity ^0.8.9;
 
 interface IERC677Receiver {
+    /** @dev onTokenTransfer implementation MUST start with check that `msg.sender == tokenAddress` */
     function onTokenTransfer(address sender, uint256 value, bytes calldata data) external;
 }

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorFactory.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorFactory.sol
@@ -34,6 +34,7 @@ contract OperatorFactory is Initializable, UUPSUpgradeable, AccessControlUpgrade
     error NotDelegationPolicy();
     error NotExchangeRatePolicy();
     error NotUndelegationPolicy();
+    error AccessDeniedDATATokenOnly();
 
     address public operatorTemplate;
     address public nodeModuleTemplate;
@@ -122,6 +123,7 @@ contract OperatorFactory is Initializable, UUPSUpgradeable, AccessControlUpgrade
             address[3] memory policies,
             uint[3] memory policyParams
         ) = abi.decode(param, (uint, string, string, address[3], uint[3]));
+        if (msg.sender != tokenAddress) { revert AccessDeniedDATATokenOnly(); }
         address operatorContractAddress = _deployOperator(
             from,
             operatorsCutFraction,

--- a/packages/network-contracts/contracts/OperatorTokenomics/SponsorshipFactory.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/SponsorshipFactory.sol
@@ -23,6 +23,7 @@ contract SponsorshipFactory is Initializable, AccessControlUpgradeable, UUPSUpgr
     error BadArguments();
     error AllocationPolicyRequired();
     error PolicyNotTrusted();
+    error AccessDeniedDATATokenOnly();
 
     StreamrConfig public streamrConfig;
     address public sponsorshipContractTemplate;
@@ -87,6 +88,7 @@ contract SponsorshipFactory is Initializable, AccessControlUpgradeable, UUPSUpgr
             address[] memory policies,
             uint[] memory policyParams
         ) = abi.decode(param, (uint, string, string, address[], uint[]));
+        if (msg.sender != tokenAddress) { revert AccessDeniedDATATokenOnly(); }
         address sponsorshipAddress = _deploySponsorship(
             minOperatorCount,
             streamId,

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/OperatorFactory.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/OperatorFactory.test.ts
@@ -157,6 +157,39 @@ describe("OperatorFactory", function(): void {
             .to.be.reverted
     })
 
+    it("transferAndCall reverts for wrong token", async function(): Promise<void> {
+        const {
+            operatorFactory,
+            token,
+            defaultDelegationPolicy,
+            defaultExchangeRatePolicy,
+            defaultUndelegationPolicy
+        } = await deployTestContracts(deployer)
+        const wrongToken = await (await getContractFactory("TestToken", { deployer })).deploy("TestToken", "TEST")
+        await (await wrongToken.mint(deployer.address, parseEther("1000"))).wait()
+        const operatorsCutFraction = parseEther("0.1")
+        const data = defaultAbiCoder.encode(["uint", "string", "string", "address[3]", "uint[3]"],
+            [
+                operatorsCutFraction,
+                "TransferAndCallWrongToken",
+                "{}",
+                [
+                    defaultDelegationPolicy.address,
+                    defaultExchangeRatePolicy.address,
+                    defaultUndelegationPolicy.address
+                ],
+                [
+                    0,
+                    0,
+                    0
+                ]
+            ]
+        )
+
+        await expect(wrongToken.connect(deployer).transferAndCall(operatorFactory.address, parseEther("1000"), data))
+            .to.be.revertedWithCustomError(operatorFactory, "AccessDeniedDATATokenOnly")
+    })
+
     it("predicts the correct address for a new operator contract", async function(): Promise<void> {
         const contracts = await deployTestContracts(deployer)
         const predictedOperatorAddress = await contracts.operatorFactory.predictAddress("PredictTest")

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/OperatorFactory.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/OperatorFactory.test.ts
@@ -159,7 +159,6 @@ describe("OperatorFactory", function(): void {
     it("transferAndCall reverts for wrong token", async function(): Promise<void> {
         const {
             operatorFactory,
-            token,
             defaultDelegationPolicy,
             defaultExchangeRatePolicy,
             defaultUndelegationPolicy

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipFactory.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipFactory.test.ts
@@ -147,6 +147,27 @@ describe("SponsorshipFactory", () => {
         expect(newSponsorshipEvent.args.streamId).to.equal(streamId)
     })
 
+    it("transferAndCall reverts for wrong token", async function(): Promise<void> {
+        const { allocationPolicy, leavePolicy, sponsorshipFactory, deployer, streamRegistry } = contracts
+        const wrongToken = await (await getContractFactory("TestToken", { deployer })).deploy("TestToken", "TEST")
+        await (await wrongToken.mint(deployer.address, parseEther("1000"))).wait()
+
+        const streamId = await createStream(deployer.address, streamRegistry)
+        const data = defaultAbiCoder.encode(["uint", "string", "string", "address[]", "uint[]"],
+            [1, streamId, "{}", [
+                allocationPolicy.address,
+                leavePolicy.address,
+                "0x0000000000000000000000000000000000000000",
+            ], [
+                "2000000000000000000",
+                "0",
+                "0",
+            ]]
+        )
+        await expect(wrongToken.transferAndCall(sponsorshipFactory.address, parseEther("100"), data))
+            .to.be.revertedWithCustomError(contracts.sponsorshipFactory, "AccessDeniedDATATokenOnly")
+    })
+
     it("will NOT create a Sponsorship with zero minOperatorCount", async function(): Promise<void> {
         const { allocationPolicy, leavePolicy, sponsorshipFactory, token, deployer, streamRegistry } = contracts
         const streamId = await createStream(deployer.address, streamRegistry)


### PR DESCRIPTION
Sponsorship and Operator contracts already had them.
