### PR TITLE
ETH-657 fix division by 0 in queue payment when totalSupply = 0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30994,7 +30994,7 @@
         "@ethersproject/providers": "^5.7.2",
         "@ethersproject/units": "^5.7.0",
         "@ethersproject/wallet": "^5.7.0",
-        "@streamr/config": "^4.0.5",
+        "@streamr/config": "4.0.10",
         "debug": "^4.3.4",
         "eth-ens-namehash": "^2.0.8",
         "node-fetch": "2.6.7",
@@ -31786,7 +31786,7 @@
     },
     "packages/network-contracts": {
       "name": "@streamr/network-contracts",
-      "version": "7.0.1",
+      "version": "7.0.2",
       "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
       "dependencies": {
         "@chainlink/contracts": "0.3.1",

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/DefaultExchangeRatePolicy.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/DefaultExchangeRatePolicy.sol
@@ -22,10 +22,10 @@ contract DefaultExchangeRatePolicy is IExchangeRatePolicy, Operator {
      * @return dataWei Amount of DATA token that would be received from the undelegation
      */
     function operatorTokenToData(uint operatorTokenWei) external view returns (uint dataWei) {
-        // guards against sending DATA to the operator contract without transferAndCall,
-        // so there is no totalSupply but non-zero valueWithoutEarnings
-        // also noone can get the DATA in that case, only operator by delegating first
-        if (this.totalSupply() == 0) {
+        // guards against queue payout when totalSupply() == 0
+        // zero totalSupply but non-zero valueWithoutEarnings can be caused by sending DATA to the operator contract without transferAndCall (using ERC20.transfer)
+        // also no one can get the DATA in that case, except the operator by doing the first self-delegation
+        if (totalSupply() == 0) {
             return 0;
         }
         return operatorTokenWei * valueWithoutEarnings() / this.totalSupply();

--- a/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/DefaultExchangeRatePolicy.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/OperatorPolicies/DefaultExchangeRatePolicy.sol
@@ -22,7 +22,12 @@ contract DefaultExchangeRatePolicy is IExchangeRatePolicy, Operator {
      * @return dataWei Amount of DATA token that would be received from the undelegation
      */
     function operatorTokenToData(uint operatorTokenWei) external view returns (uint dataWei) {
-        // don't guard here against this.totalSupply() == 0 because: no tokens in supply => nothing to undelegate => ?!
+        // guards against sending DATA to the operator contract without transferAndCall,
+        // so there is no totalSupply but non-zero valueWithoutEarnings
+        // also noone can get the DATA in that case, only operator by delegating first
+        if (this.totalSupply() == 0) {
+            return 0;
+        }
         return operatorTokenWei * valueWithoutEarnings() / this.totalSupply();
     }
 

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
@@ -1509,7 +1509,7 @@ describe("Operator contract", (): void => {
             const { token } = sharedContracts
             await setTokens(delegator, "100")
             const { operator } = await deployOperator(operatorWallet)
-            
+
             await (await token.connect(delegator).transferAndCall(operator.address, parseEther("100"), "0x")).wait()
 
             await expect(operator.connect(delegator).undelegate(hardhatEthers.constants.MaxUint256))
@@ -1520,12 +1520,16 @@ describe("Operator contract", (): void => {
             const { token } = sharedContracts
             await setTokens(delegator, "100")
             const { operator } = await deployOperator(operatorWallet)
-            
+
             await (await token.connect(delegator).transfer(operator.address, parseEther("100"))).wait()
 
             await (await operator.connect(delegator).undelegate(hardhatEthers.constants.MaxUint256)).wait()
 
+            // queue item will be popped but nothing is sent out
             await expect(operator.payOutFirstInQueue()).to.not.throw
+            expect(await operator.queueIsEmpty()).to.equal(true)
+            expect(await token.balanceOf(delegator.address)).to.equal(parseEther("0"))
+            expect(await token.balanceOf(operator.address)).to.equal(parseEther("100"))
         })
     })
 

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
@@ -1516,7 +1516,7 @@ describe("Operator contract", (): void => {
                 .to.emit(operator, "Undelegated").withArgs(delegator.address, parseEther("100"))
         })
 
-        it.only("undelegate when there was never a delegation, but transfer (not transferAndCall) of tokens", async function(): Promise<void> {
+        it("undelegate when there was never a delegation, but transfer (not transferAndCall) of tokens", async function(): Promise<void> {
             const { token } = sharedContracts
             await setTokens(delegator, "100")
             const { operator } = await deployOperator(operatorWallet)

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Operator.test.ts
@@ -1515,6 +1515,18 @@ describe("Operator contract", (): void => {
             await expect(operator.connect(delegator).undelegate(hardhatEthers.constants.MaxUint256))
                 .to.emit(operator, "Undelegated").withArgs(delegator.address, parseEther("100"))
         })
+
+        it.only("undelegate when there was never a delegation, but transfer (not transferAndCall) of tokens", async function(): Promise<void> {
+            const { token } = sharedContracts
+            await setTokens(delegator, "100")
+            const { operator } = await deployOperator(operatorWallet)
+            
+            await (await token.connect(delegator).transfer(operator.address, parseEther("100"))).wait()
+
+            await (await operator.connect(delegator).undelegate(hardhatEthers.constants.MaxUint256)).wait()
+
+            await expect(operator.payOutFirstInQueue()).to.not.throw
+        })
     })
 
     describe("Kick/slash handler", () => {


### PR DESCRIPTION
…to new and empty operator contract (totalSupply of pooltokens = 0) and then going to undelegation queue