### PR TITLE
ETH-686: minimum stake calculation

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Sponsorship.sol
@@ -39,8 +39,8 @@ import "./StreamrConfig.sol";
  * @dev   either via _stake/_slash (to/from stake) or _addSponsorship (to remainingWei)
  */
 contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, AccessControlUpgradeable {
-
-    event StakeUpdate(address indexed operator, uint stakedWei, uint earningsWei, uint lockedStakeWei);
+    // Emitted from this contract
+    event StakeUpdate(address indexed operator, uint stakedWei, uint earningsWei);
     event SponsorshipUpdate(uint totalStakedWei, uint remainingWei, uint operatorCount, bool isRunning);
     event OperatorJoined(address indexed operator);
     event OperatorLeft(address indexed operator, uint returnedStakeWei);
@@ -56,12 +56,13 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
     // Emitted from VoteKickPolicy
     event Flagged(address indexed target, address indexed flagger, uint targetStakeAtRiskWei, uint reviewerCount, string flagMetadata);
     event FlagUpdate(address indexed target, IKickPolicy.FlagState indexed status, uint votesForKick, uint votesAgainstKick, address indexed voter, int voterWeight);
+    event StakeLockUpdate(address indexed operator, uint lockedStakeWei, uint minimumStakeWei);
 
     error AccessDenied();
     error OnlyDATAToken();
     error MinOperatorCountZero();
-    error MinimumStake();
-    error CannotIncreaseStake();
+    error MinimumStake(uint minimumStakeWei);
+    error CannotIncreaseStakeUsingReduceStakeTo();
     error OperatorNotStaked();
     error LeavePenalty(uint penaltyWei); // prevents unstake()
     error ActiveFlag(uint lockedStakeWei); // prevents unstake()
@@ -81,7 +82,7 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
 
     mapping(address => uint) public stakedWei; // how much each operator has staked, if 0 operator is considered not part of sponsorship
     mapping(address => uint) public joinTimeOfOperator;
-    mapping(address => uint) public lockedStakeWei; // how much can not be unstaked (during e.g. flagging)
+    mapping(address => uint) public lockedStakeWei; // how much stake can not be taken out with forceUnstake or reduceStake (during e.g. flagging)
     uint public forfeitedStakeWei; // lockedStakeWei that has been forfeited but is still needed to e.g. pay the flag reviewers
     uint public totalStakedWei;
     uint public operatorCount;
@@ -92,16 +93,6 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
 
     function getMyStake() public view returns (uint) {
         return stakedWei[_msgSender()];
-    }
-
-    /**
-     * You can't unstake the locked part or go below the minimum stake (by cashing out your stake),
-     *   hence there is an individual limit for reduceStakeTo.
-     * When joining, locked stake is zero, so the it's the same minimumStakeWei for everyone.
-     */
-    function minimumStakeOf(address operator) public view returns (uint) {
-        uint minimumStakeWei = streamrConfig.minimumStakeWei();
-        return max(lockedStakeWei[operator], minimumStakeWei);
     }
 
     /**
@@ -220,7 +211,8 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
         bool newStaker = stakedWei[operator] == 0;
         stakedWei[operator] += amountWei;
         totalStakedWei += amountWei;
-        if (stakedWei[operator] < streamrConfig.minimumStakeWei()) { revert MinimumStake(); }
+        uint minimumStake = minimumStakeOf(operator);
+        if (stakedWei[operator] < minimumStake) { revert MinimumStake(minimumStake); }
 
         if (newStaker) {
             operatorCount += 1;
@@ -235,7 +227,7 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
             moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onStakeChange.selector, operator, int(amountWei)));
         }
 
-        emit StakeUpdate(operator, stakedWei[operator], getEarnings(operator), lockedStakeWei[operator]);
+        emit StakeUpdate(operator, stakedWei[operator], getEarnings(operator));
         emit SponsorshipUpdate(totalStakedWei, remainingWei, uint32(operatorCount), isRunning());
     }
 
@@ -266,13 +258,14 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
     /** Reduce your stake in the sponsorship without leaving */
     function reduceStakeTo(uint targetStakeWei) external returns (uint payoutWei) {
         address operator = _msgSender();
-        if (targetStakeWei >= stakedWei[operator]) { revert CannotIncreaseStake(); }
-        if (targetStakeWei < minimumStakeOf(operator)) { revert MinimumStake(); }
+        if (targetStakeWei >= stakedWei[operator]) { revert CannotIncreaseStakeUsingReduceStakeTo(); }
+        uint minimumStake = minimumStakeOf(operator);
+        if (targetStakeWei < minimumStake) { revert MinimumStake(minimumStake); }
 
         payoutWei = _reduceStakeBy(operator, stakedWei[operator] - targetStakeWei);
         token.transfer(operator, payoutWei);
 
-        emit StakeUpdate(operator, stakedWei[operator], getEarnings(operator), lockedStakeWei[operator]);
+        emit StakeUpdate(operator, stakedWei[operator], getEarnings(operator));
         emit SponsorshipUpdate(totalStakedWei, remainingWei, uint32(operatorCount), isRunning());
     }
 
@@ -341,7 +334,7 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
         delete joinTimeOfOperator[operator];
 
         moduleCall(address(allocationPolicy), abi.encodeWithSelector(allocationPolicy.onLeave.selector, operator));
-        emit StakeUpdate(operator, 0, 0, 0); // stake and allocation must be zero when the operator is gone
+        emit StakeUpdate(operator, 0, 0); // stake and allocation must be zero when the operator is gone
         emit SponsorshipUpdate(totalStakedWei, remainingWei, uint32(operatorCount), isRunning());
         emit OperatorLeft(operator, paidOutStakeWei);
 
@@ -359,7 +352,7 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
         payoutWei = _withdraw(operator);
         if (payoutWei > 0) {
             // earnings will be zero after withdraw (see test)
-            emit StakeUpdate(operator, stakedWei[operator], 0, lockedStakeWei[operator]);
+            emit StakeUpdate(operator, stakedWei[operator], 0);
         }
     }
 
@@ -487,6 +480,11 @@ contract Sponsorship is Initializable, ERC2771ContextUpgradeable, IERC677Receive
     function getLeavePenalty(address operator) public view returns(uint leavePenalty) {
         if (address(leavePolicy) == address(0)) { return 0; }
         return moduleGet(abi.encodeWithSelector(leavePolicy.getLeavePenaltyWei.selector, operator, address(leavePolicy)));
+    }
+
+    function minimumStakeOf(address operator) public view returns (uint individualMinimumStakeWei) {
+        if (address(kickPolicy) == address(0)) { return 0; }
+        return moduleGet(abi.encodeWithSelector(kickPolicy.getMinimumStakeOf.selector, operator, address(kickPolicy)));
     }
 
     function _msgSender() internal view virtual override(ContextUpgradeable, ERC2771ContextUpgradeable) returns (address sender) {

--- a/packages/network-contracts/contracts/OperatorTokenomics/SponsorshipPolicies/AdminKickPolicy.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/SponsorshipPolicies/AdminKickPolicy.sol
@@ -30,4 +30,8 @@ contract AdminKickPolicy is IKickPolicy, Sponsorship {
     function getFlagData(address) override external pure returns (uint flagData) {
         return 0;
     }
+
+    function getMinimumStakeOf(address) override external pure returns (uint individualMinimumStakeWei) {
+        return 0;
+    }
 }

--- a/packages/network-contracts/contracts/OperatorTokenomics/SponsorshipPolicies/IKickPolicy.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/SponsorshipPolicies/IKickPolicy.sol
@@ -14,4 +14,5 @@ interface IKickPolicy {
     function onFlag(address target, address flagger) external;
     function onVote(address operator, bytes32 voteData, address voter) external;
     function getFlagData(address operator) external view returns (uint flagData);
+    function getMinimumStakeOf(address operator) external view returns (uint individualMinimumStakeWei);
 }

--- a/packages/network-contracts/contracts/OperatorTokenomics/SponsorshipPolicies/VoteKickPolicy.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/SponsorshipPolicies/VoteKickPolicy.sol
@@ -37,10 +37,33 @@ contract VoteKickPolicy is IKickPolicy, Sponsorship {
     // can't be flagged again right after a no-kick result
     mapping (address => uint) private protectionEndTimestamp;
 
-    function setParam(uint) external {
+    function setParam(uint) external {}
 
+    /**
+     * You can't cash out the locked part of your stake, or go below the minimum stake.
+     * When joining, locked stake is zero, so the limit is the same minimumStakeWei for everyone.
+     * In addition to locked stake, the individual limit must have enough room for flagging (if not already flagged). When a flag is raised:
+     *    lockedStakeAfter = lockedStakeBefore + stake * slashingFraction
+     * If we require that in all circumstances lockedStake < stake, then we get:
+     *    stake > lockedStakeAfter = lockedStakeBefore + stake * slashingFraction
+     * Solving for stake:
+     *    stake > lockedStakeBefore / (1 - slashingFraction) = minimumStake
+     */
+    function getMinimumStakeOf(address operator) override public view returns (uint) {
+        uint minimumStakeWei = streamrConfig.minimumStakeWei();
+        uint lockedStake = lockedStakeWei[operator];
+        // only bake in the "room for flagging" if not yet flagged
+        if (voteStartTimestamp[operator] == 0) { lockedStake = lockedStake * 1 ether / (1 ether - streamrConfig.slashingFraction()); }
+        return max(lockedStake, minimumStakeWei);
     }
 
+    /**
+     * Info about flag packed in 32 bytes:
+     * 20 bytes: flagger address
+     * 4 bytes: vote start timestamp
+     * 4 bytes: vote fraction for kick (100% = 2**32 = 4294967296)
+     * 4 bytes: vote fraction against kick (100% = 2**32 = 4294967296)
+     */
     function getFlagData(address target) override external view returns (uint flagData) {
         if (voteStartTimestamp[target] == 0) {
             return 0;
@@ -48,9 +71,8 @@ contract VoteKickPolicy is IKickPolicy, Sponsorship {
         return uint(bytes32(abi.encodePacked(
             uint160(flaggerAddress[target]),
             uint32(voteStartTimestamp[target]),
-            uint16(2**16 * votesForKick[target] / votersTotalValueWei[target]),
-            uint16(2**16 * votesAgainstKick[target] / votersTotalValueWei[target])
-            // uint32() unused space
+            uint32(2**32 * votesForKick[target] / votersTotalValueWei[target]),
+            uint32(2**32 * votesAgainstKick[target] / votersTotalValueWei[target])
         )));
     }
 
@@ -60,11 +82,10 @@ contract VoteKickPolicy is IKickPolicy, Sponsorship {
     function onFlag(address target, address flagger) external {
         require(flagger != target, "error_cannotFlagSelf");
         require(voteStartTimestamp[target] == 0 && block.timestamp > protectionEndTimestamp[target], "error_cannotFlagAgain"); // solhint-disable-line not-rely-on-time
-        require(stakedWei[flagger] >= minimumStakeOf(flagger), "error_notEnoughStake");
         require(stakedWei[target] > 0, "error_flagTargetNotStaked");
 
         // the flag target risks to lose a slashingFraction if the flag resolves to KICK
-        // take at least slashingFraction of minimumStakeWei to ensure everyone can get paid!
+        // take at least slashingFraction of minimumStakeWei to ensure everyone can get paid, even if the target somehow has managed to go under the minimum stake
         targetStakeAtRiskWei[target] = max(stakedWei[target], streamrConfig.minimumStakeWei()) * streamrConfig.slashingFraction() / 1 ether;
         lockedStakeWei[target] += targetStakeAtRiskWei[target];
 
@@ -85,8 +106,9 @@ contract VoteKickPolicy is IKickPolicy, Sponsorship {
         reviewerRewardWei[target] = streamrConfig.flagReviewerRewardWei();
         flaggerRewardWei[target] = streamrConfig.flaggerRewardWei();
 
+        // added locked stake may also raise the flagger's minimum stake
         lockedStakeWei[flagger] += flagStakeWei[target];
-        require(lockedStakeWei[flagger] * 1 ether <= stakedWei[flagger] * (1 ether - streamrConfig.slashingFraction()), "error_notEnoughStake");
+        require(stakedWei[flagger] >= minimumStakeOf(flagger), "error_notEnoughStake");
 
         IVoterRegistry voterRegistry = IVoterRegistry(streamrConfig.voterRegistry());
         uint voterCount = voterRegistry.voterCount();
@@ -138,8 +160,8 @@ contract VoteKickPolicy is IKickPolicy, Sponsorship {
         votersTotalValueWei[target] = totalValueWei;
         require(reviewers[target].length > 0, "error_failedToFindReviewers");
 
-        emit StakeUpdate(flagger, stakedWei[flagger], getEarnings(flagger), lockedStakeWei[flagger]);
-        emit StakeUpdate(target, stakedWei[target], getEarnings(target), lockedStakeWei[target]);
+        emit StakeLockUpdate(flagger, lockedStakeWei[flagger], getMinimumStakeOf(flagger));
+        emit StakeLockUpdate(target, lockedStakeWei[target], getMinimumStakeOf(target));
         emit Flagged(target, flagger, targetStakeAtRiskWei[target], reviewers[target].length, flagMetadataJson[target]);
     }
 
@@ -243,12 +265,12 @@ contract VoteKickPolicy is IKickPolicy, Sponsorship {
             }
             emit FlagUpdate(target, FlagState.NOT_KICKED, votesForKick[target], votesAgainstKick[target], address(0), 0);
             if (!targetIsGone) {
-                emit StakeUpdate(target, stakedWei[target], getEarnings(target), lockedStakeWei[target]);
+                emit StakeLockUpdate(target, lockedStakeWei[target], getMinimumStakeOf(target));
             }
         }
 
         if (!flaggerIsGone) {
-            emit StakeUpdate(flagger, stakedWei[flagger], getEarnings(flagger), lockedStakeWei[flagger]);
+            emit StakeLockUpdate(flagger, lockedStakeWei[flagger], getMinimumStakeOf(flagger));
         }
         emit SponsorshipUpdate(totalStakedWei, remainingWei, uint32(operatorCount), isRunning());
 

--- a/packages/network-contracts/contracts/OperatorTokenomics/StreamrConfig.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/StreamrConfig.sol
@@ -15,8 +15,9 @@ contract StreamrConfig is Initializable, AccessControlUpgradeable, UUPSUpgradeab
     error TooLow(uint value, uint limit);
 
     /**
-     * Minimum amount to pay reviewers+flagger
-     * That is: minimumStakeWei >= (flaggerRewardWei + flagReviewerCount * flagReviewerRewardWei) / slashingFraction
+     * Minimum stake whose slashing is enough to pay reviewers+flagger in case of a voting that results in KICK.
+     * That is: minimumStakeWei * slashingFraction >= flaggerRewardWei + flagReviewerCount * flagReviewerRewardWei
+     * Round UP so that the possible rounding error doesn't cause reward money to run out.
      */
     function minimumStakeWei() public view returns (uint) {
         return ((flaggerRewardWei + flagReviewerCount * flagReviewerRewardWei) * 1 ether + slashingFraction - 1) / slashingFraction;

--- a/packages/network-contracts/contracts/OperatorTokenomics/testcontracts/TestKickPolicy.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/testcontracts/TestKickPolicy.sol
@@ -24,4 +24,8 @@ contract TestKickPolicy is IKickPolicy, Sponsorship {
     function getFlagData(address operator) override external view returns (uint flagData) {
         return operator.balance;
     }
+
+    function getMinimumStakeOf(address) override external pure returns (uint individualMinimumStakeWei) {
+        return 0;
+    }
 }

--- a/packages/network-contracts/selectors.txt
+++ b/packages/network-contracts/selectors.txt
@@ -190,6 +190,7 @@ Function signatures:
 ======= OperatorTokenomics/sol:IKickPolicy =======
 Function signatures:
 c0275535: getFlagData(address)
+09f359be: getMinimumStakeOf(address)
 d11d8fc4: onFlag(address,address)
 fbbabed9: onVote(address,bytes32,address)
 4a45d2e6: setParam(uint256)
@@ -515,11 +516,11 @@ a5b83ce4: voteOnFlag(address,bytes32)
 Error signatures:
 4ca88867: AccessDenied()
 bbef3e1a: ActiveFlag(uint256)
-369ae979: CannotIncreaseStake()
+aa4c0757: CannotIncreaseStakeUsingReduceStakeTo()
 4274cbe6: FlaggingNotSupported()
 078759ac: LeavePenalty(uint256)
 c27c6c34: MinOperatorCountZero()
-047e14bb: MinimumStake()
+0be9186a: MinimumStake(uint256)
 918623b7: ModuleCallError(address,bytes)
 29801d70: ModuleGetError(bytes)
 7377079b: OnlyDATAToken()
@@ -541,7 +542,8 @@ bd79b86ffe0ab8e8776151514217cd7cacd52c909f66475c3af44e129f0b00ff: RoleAdminChang
 f6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b: RoleRevoked(bytes32,address,address)
 e3e06f75e3a1529da79c083b1d8dd06fd928c2e268b3e2aaffa6103a14bcbd99: SponsorshipReceived(address,uint256)
 38a9ab06ef5f5ea75fd622f984e03b2393343b6039c656e874e3fa9e3ddcd7b2: SponsorshipUpdate(uint256,uint256,uint256,bool)
-6bd50b2adbfd6455ea19dde2d7225e43f70fab44edfbac7ed0748d7d9c3f9059: StakeUpdate(address,uint256,uint256,uint256)
+7785543bdf6fdde3b8486c62fa277837a6032d5819acf53e664ef0c45332fcb2: StakeLockUpdate(address,uint256,uint256)
+5d179bbeed3396160151c93c13d38566dc1643f25a316cca998cd25f45a8bd3f: StakeUpdate(address,uint256,uint256)
 
 ======= OperatorTokenomics/sol:SponsorshipFactory =======
 Function signatures:

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/Sponsorship.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/Sponsorship.test.ts
@@ -287,7 +287,7 @@ describe("Sponsorship contract", (): void => {
             await (await sponsorship.sponsor(parseEther("10000"))).wait()
             await (await token.connect(operator).transferAndCall(sponsorship.address, parseEther("100"), operator.address)).wait()
             await expect(sponsorship.connect(operator).reduceStakeTo(parseEther("150")))
-                .to.be.revertedWithCustomError(sponsorship, "CannotIncreaseStake")
+                .to.be.revertedWithCustomError(sponsorship, "CannotIncreaseStakeUsingReduceStakeTo")
         })
 
         it("won't let unstake if you would be slashed", async function(): Promise<void> {
@@ -300,9 +300,9 @@ describe("Sponsorship contract", (): void => {
 
         it("won't let you reduceStake if you're not staked", async function(): Promise<void> {
             await expect(defaultSponsorship.connect(operator).reduceStakeTo(0))
-                .to.be.revertedWithCustomError(defaultSponsorship, "CannotIncreaseStake")
+                .to.be.revertedWithCustomError(defaultSponsorship, "CannotIncreaseStakeUsingReduceStakeTo")
             await expect(defaultSponsorship.connect(operator).reduceStakeTo(parseEther("1")))
-                .to.be.revertedWithCustomError(defaultSponsorship, "CannotIncreaseStake")
+                .to.be.revertedWithCustomError(defaultSponsorship, "CannotIncreaseStakeUsingReduceStakeTo")
         })
 
         it("won't let you unstake if you're not staked", async function(): Promise<void> {
@@ -457,9 +457,9 @@ describe("Sponsorship contract", (): void => {
         })
         it("cannot reduceStakeTo", async function(): Promise<void> {
             await expect(defaultSponsorship.connect(operator2).reduceStakeTo(parseEther("1")))
-                .to.be.revertedWithCustomError(defaultSponsorship, "CannotIncreaseStake")
+                .to.be.revertedWithCustomError(defaultSponsorship, "CannotIncreaseStakeUsingReduceStakeTo")
             await expect(defaultSponsorship.connect(operator2).reduceStakeTo(parseEther("0")))
-                .to.be.revertedWithCustomError(defaultSponsorship, "CannotIncreaseStake")
+                .to.be.revertedWithCustomError(defaultSponsorship, "CannotIncreaseStakeUsingReduceStakeTo")
         })
         it("cannot withdraw", async function(): Promise<void> {
             await expect(defaultSponsorship.connect(operator2).withdraw())

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/StakeWeightedAllocationPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/StakeWeightedAllocationPolicy.test.ts
@@ -201,12 +201,12 @@ describe("StakeWeightedAllocationPolicy", (): void => {
 
         await advanceToTimestamp(timeAtStart, "Operator joins")
         await expect(token.connect(operator).transferAndCall(sponsorship.address, parseEther("400"), operator.address))
-            .to.emit(sponsorship, "StakeUpdate").withArgs(operator.address, parseEther("400"), parseEther("0"), parseEther("0"))
+            .to.emit(sponsorship, "StakeUpdate").withArgs(operator.address, parseEther("400"), parseEther("0"))
             .to.emit(sponsorship, "SponsorshipUpdate").withArgs(parseEther("400"), parseEther("12345"), 1, true)
 
         await advanceToTimestamp(timeAtStart + 1000, "Operator adds 100 stake 400 -> 500")
         await expect(token.connect(operator).transferAndCall(sponsorship.address, parseEther("100"), operator.address))
-            .to.emit(sponsorship, "StakeUpdate").withArgs(operator.address, parseEther("500"), parseEther("1000"), parseEther("0"))
+            .to.emit(sponsorship, "StakeUpdate").withArgs(operator.address, parseEther("500"), parseEther("1000"))
             .to.emit(sponsorship, "SponsorshipUpdate").withArgs(parseEther("500"), parseEther("11345"), 1, true)
 
         await advanceToTimestamp(timeAtStart + 2000, "Operator leaves")

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/VoteKickPolicy.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/SponsorshipPolicies/VoteKickPolicy.test.ts
@@ -3,7 +3,7 @@ import { expect } from "chai"
 
 import { deployTestContracts, TestContracts } from "../deployTestContracts"
 import { setupSponsorships, SponsorshipTestSetup } from "../setupSponsorships"
-import { advanceToTimestamp, getBlockTimestamp, VOTE_KICK, VOTE_NO_KICK, VOTE_START, VOTE_END, END_PROTECTION } from "../utils"
+import { advanceToTimestamp, getBlockTimestamp, VOTE_KICK, VOTE_NO_KICK, VOTE_START, VOTE_END, END_PROTECTION, log } from "../utils"
 
 import type { MockRandomOracle } from "../../../../typechain"
 import type { BigNumber, Wallet } from "ethers"
@@ -15,8 +15,8 @@ function parseFlag(flagData: BigNumber) {
     return {
         flagger: getAddress(hexZeroPad(flagData.shr(96).mask(160).toHexString(), 20)),
         startDate: new Date(flagData.shr(64).mask(32).toNumber() * 1000),
-        fractionForKick: flagData.shr(48).mask(16).toNumber() / 2**16,
-        fractionAgainstKick: flagData.shr(32).mask(16).toNumber() / 2**16,
+        fractionForKick: flagData.shr(32).mask(32).toNumber() / 2**32,
+        fractionAgainstKick: flagData.mask(32).toNumber() / 2**32,
     }
 }
 
@@ -118,6 +118,14 @@ describe("VoteKickPolicy", (): void => {
             await expect(voter2.voteOnFlag(sponsorship.address, target.address, VOTE_NO_KICK)).to.emit(sponsorship, "FlagUpdate").withArgs(
                 target.address, FlagState.VOTING, parseEther("10000"), parseEther("10000"), voter2.address, parseEther("-10000")
             )
+
+            const { flagData } = await sponsorship.getFlag(target.address)
+            expect(parseFlag(flagData)).to.contain({
+                flagger: flagger.address,
+                fractionForKick: 0.3333333332557231,
+                fractionAgainstKick: 0.3333333332557231,
+            })
+
             await expect(voter3.voteOnFlag(sponsorship.address, target.address, VOTE_KICK)).to.emit(sponsorship, "FlagUpdate").withArgs(
                 target.address, FlagState.VOTING, parseEther("20000"), parseEther("10000"), voter3.address, parseEther("10000")
             ).to.emit(sponsorship, "FlagUpdate").withArgs(
@@ -571,7 +579,7 @@ describe("VoteKickPolicy", (): void => {
     })
 
     describe("Stake locking", (): void => {
-        it("allows the target to reduce stake the correct amount DURING the flag period (to amount stake locked)", async function(): Promise<void> {
+        it("allows the target to reduce stake the correct amount DURING the flag period", async function(): Promise<void> {
             const {
                 sponsorships: [ sponsorship ],
                 operators: [ flagger, target, voter ]
@@ -589,7 +597,7 @@ describe("VoteKickPolicy", (): void => {
             await expect(flagger.unstake(sponsorship.address)).to.be.revertedWithCustomError(sponsorship, "ActiveFlag")
             await expect(target.reduceStakeTo(sponsorship.address, parseEther("9999"))).to.be.revertedWithCustomError(sponsorship, "MinimumStake")
             await expect(target.reduceStakeTo(sponsorship.address, parseEther("10000")))
-                .to.emit(sponsorship, "StakeUpdate").withArgs(target.address, parseEther("10000"), parseEther("0"), parseEther("10000"))
+                .to.emit(sponsorship, "StakeUpdate").withArgs(target.address, parseEther("10000"), parseEther("0"))
         })
 
         it("allows the target to unstake AFTER the flag resolves to NO_KICK", async function(): Promise<void> {
@@ -613,22 +621,42 @@ describe("VoteKickPolicy", (): void => {
                 .to.emit(sponsorship, "OperatorLeft").withArgs(target.address, parseEther("10000"))
         })
 
-        it("allows the flagger to reduce stake the correct amount DURING the flag period (to amount stake locked)", async function(): Promise<void> {
+        it("allows the flagger to reduce stake the correct amount DURING the flag period", async function(): Promise<void> {
             const {
                 sponsorships: [ sponsorship ],
                 operators: [flagger, ...targets]
-            } = await setupSponsorships(contracts, [13], "flagger-reducestake")
+            } = await setupSponsorships(contracts, [19], "flagger-reducestake", {
+                stakeAmountWei: parseEther("100000")
+            })
 
-            for (const target of targets) {
-                await expect(flagger.flag(sponsorship.address, target.address, "")).to.emit(sponsorship, "Flagged")
-            }
+            /* eslint-disable max-len */
+            await expect(flagger.flag(sponsorship.address, targets[0].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("500"), parseEther("5000"))
+            await expect(flagger.flag(sponsorship.address, targets[1].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("1000"), parseEther("5000"))
+            await expect(flagger.flag(sponsorship.address, targets[2].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("1500"), parseEther("5000"))
+            await expect(flagger.flag(sponsorship.address, targets[3].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("2000"), parseEther("5000"))
+            await expect(flagger.flag(sponsorship.address, targets[4].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("2500"), parseEther("5000"))
+            await expect(flagger.flag(sponsorship.address, targets[5].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("3000"), parseEther("5000"))
+            await expect(flagger.flag(sponsorship.address, targets[6].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("3500"), parseEther("5000"))
+            await expect(flagger.flag(sponsorship.address, targets[7].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("4000"), parseEther("5000"))
+            await expect(flagger.flag(sponsorship.address, targets[8].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("4500"), parseEther("5000"))
+            await expect(flagger.flag(sponsorship.address, targets[9].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("5000"), parseEther("5555.555555555555555555"))
+            await expect(flagger.flag(sponsorship.address, targets[10].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("5500"), parseEther("6111.111111111111111111"))
+            await expect(flagger.flag(sponsorship.address, targets[11].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("6000"), parseEther("6666.666666666666666666"))
+            await expect(flagger.flag(sponsorship.address, targets[12].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("6500"), parseEther("7222.222222222222222222"))
+            await expect(flagger.flag(sponsorship.address, targets[13].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("7000"), parseEther("7777.777777777777777777"))
+            await expect(flagger.flag(sponsorship.address, targets[14].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("7500"), parseEther("8333.333333333333333333"))
+            await expect(flagger.flag(sponsorship.address, targets[15].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("8000"), parseEther("8888.888888888888888888"))
+            await expect(flagger.flag(sponsorship.address, targets[16].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("8500"), parseEther("9444.444444444444444444"))
+            await expect(flagger.flag(sponsorship.address, targets[17].address, "")).to.emit(sponsorship, "StakeLockUpdate").withArgs(flagger.address, parseEther("9000"), parseEther("10000"))
+            /* eslint-enable max-len */
 
-            const minimumStake = await sponsorship.minimumStakeOf(flagger.address)
-            expect(formatEther(minimumStake)).to.equal("6000.0")
+            // lockedStake 18 * 500 = 9000, plus room for 10% slashing = 10000
+            // 10000 > global minimumStake 5000 ==> flagger's minimumStake = 10000
+            expect(formatEther(await sponsorship.minimumStakeOf(flagger.address))).to.equal("10000.0")
             await expect(flagger.unstake(sponsorship.address)).to.be.revertedWithCustomError(sponsorship, "ActiveFlag")
-            await expect(flagger.reduceStakeTo(sponsorship.address, parseEther("5999"))).to.be.revertedWithCustomError(sponsorship, "MinimumStake")
-            await expect(flagger.reduceStakeTo(sponsorship.address, parseEther("6000")))
-                .to.emit(sponsorship, "StakeUpdate").withArgs(flagger.address, parseEther("6000"), parseEther("0"), parseEther("6000"))
+            await expect(flagger.reduceStakeTo(sponsorship.address, parseEther("9999"))).to.be.revertedWithCustomError(sponsorship, "MinimumStake")
+            await expect(flagger.reduceStakeTo(sponsorship.address, parseEther("10000")))
+                .to.emit(sponsorship, "StakeUpdate").withArgs(flagger.address, parseEther("10000"), parseEther("0"))
         })
 
         it("allows the flagger to unstake AFTER the flag resolves to NO_KICK", async function(): Promise<void> {
@@ -715,7 +743,7 @@ describe("VoteKickPolicy", (): void => {
             expect(await sponsorship.minimumStakeOf(flagger.address)).to.equal(minimumStakeWei)
 
             await expect(flagger.reduceStakeTo(sponsorship.address, minimumStakeWei))
-                .to.emit(sponsorship, "StakeUpdate").withArgs(flagger.address, minimumStakeWei, parseEther("0"), parseEther("0"))
+                .to.emit(sponsorship, "StakeUpdate").withArgs(flagger.address, minimumStakeWei, parseEther("0"))
 
             await advanceToTimestamp(start, `${addr(flagger)} flags ${addr(target)}`)
             await expect(flagger.flag(sponsorship.address, target.address, ""))
@@ -825,6 +853,42 @@ describe("VoteKickPolicy", (): void => {
 
             await expect(flagger.flag(sponsorship.address, targets[9].address, ""))
                 .to.be.revertedWith("error_notEnoughStake")
+        })
+
+        it("ensures a super-flagger that reduces stake to minimum can still be flagged", async function(): Promise<void> {
+            // maximal flagging is 9 flags, see "not enough (unlocked) stake" test case
+            const {
+                sponsorships: [ sponsorship ],
+                operators: [ flagger, ...targets ]
+            } = await setupSponsorships(contracts, [20], "super-flagger-2", {
+                stakeAmountWei: parseEther("15000"), // flag-stake is 500 tokens
+            })
+            const start = await getBlockTimestamp()
+
+            await advanceToTimestamp(start, `${addr(flagger)} flags`)
+            for (const target of targets.slice(0, 18)) {
+                log("    %s", addr(target))
+                await (await flagger.flag(sponsorship.address, target.address, "")).wait()
+            }
+
+            // lockedStake 18 * 500 = 9000, plus room for 10% slashing = 10000
+            // 10000 > global minimumStake 5000 ==> flagger's minimumStake = 10000
+            expect(formatEther(await sponsorship.lockedStakeWei(flagger.address))).to.equal("9000.0")
+            expect(formatEther(await sponsorship.minimumStakeOf(flagger.address))).to.equal("10000.0")
+            expect(formatEther(await sponsorship.stakedWei(flagger.address))).to.equal("15000.0")
+
+            await expect(flagger.reduceStakeTo(sponsorship.address, parseEther("10000")))
+                .to.emit(sponsorship, "StakeUpdate").withArgs(flagger.address, parseEther("10000"), parseEther("0"))
+
+            // expecting to be able to open the flag
+            await advanceToTimestamp(start + 1000, `${addr(targets[0])} flags ${addr(flagger)}`)
+            await expect(targets[0].flag(sponsorship.address, flagger.address, ""))
+                .to.emit(sponsorship, "Flagged").withArgs(flagger.address, targets[0].address, parseEther("1000"), 7, "")
+
+            // now all of the stake is locked
+            expect(formatEther(await sponsorship.lockedStakeWei(flagger.address))).to.equal("10000.0")
+            expect(formatEther(await sponsorship.stakedWei(flagger.address))).to.equal("10000.0")
+            expect(formatEther(await sponsorship.minimumStakeOf(flagger.address))).to.equal("10000.0")
         })
 
         it("ensures a flagger that opens flags maximally can still pay the early leave penalty", async function(): Promise<void> {

--- a/packages/network-contracts/test/hardhat/OperatorTokenomics/StreamrConfig.test.ts
+++ b/packages/network-contracts/test/hardhat/OperatorTokenomics/StreamrConfig.test.ts
@@ -54,10 +54,10 @@ describe("StreamrConfig", (): void => {
                     .to.emit(sponsorship, "SponsorshipReceived").withArgs(admin.address, parseEther("1000"))
                 await expect(flagger.stake(sponsorship.address, parseEther("100000")))
                     .to.emit(flagger, "Staked").withArgs(sponsorship.address)
-                    .to.emit(sponsorship, "StakeUpdate").withArgs(flagger.address, parseEther("100000"), "0", "0")
+                    .to.emit(sponsorship, "StakeUpdate").withArgs(flagger.address, parseEther("100000"), "0")
                 await expect(target.stake(sponsorship.address, minimumStakeWei))
                     .to.emit(target, "Staked").withArgs(sponsorship.address)
-                    .to.emit(sponsorship, "StakeUpdate").withArgs(target.address, minimumStakeWei, "0", "0")
+                    .to.emit(sponsorship, "StakeUpdate").withArgs(target.address, minimumStakeWei, "0")
 
                 // raise the targetStakeAtRiskWei by raising minimum stake by setting higher reviewer rewards
                 // minimum stake goes up to 73600.0, slashingFraction of that is 7360 > 5000 that `target` staked

--- a/packages/network-contracts/test/integration/contractsSubgraphSmoketest.test.ts
+++ b/packages/network-contracts/test/integration/contractsSubgraphSmoketest.test.ts
@@ -24,19 +24,14 @@ describe("docker image integration test", () => {
     it("can get all the indexed example data from thegraph", async () => {
         const resultDynamicIds = await graphClient.queryEntity<any>({ query: `
         {
-            operatorDailyBuckets {
-                id
+            sponsorships {
+                id,
+                maxOperators
             }
             sponsorshipDailyBuckets {
                 id
             }
-            stakingEvents {
-                id
-            }
             sponsoringEvents {
-                id
-            }
-            delegations {
                 id
             }
             nodes {
@@ -45,9 +40,14 @@ describe("docker image integration test", () => {
             operators {
                 id
             }
-            sponsorships {
-                id,
-                maxOperators
+            operatorDailyBuckets {
+                id
+            }
+            delegations {
+                id
+            }
+            stakingEvents {
+                id
             }
             stakes {
                 id
@@ -64,17 +64,17 @@ describe("docker image integration test", () => {
             }
         }
         `})
-        expect(resultDynamicIds.nodes.length).to.equal(1)
         expect(resultDynamicIds.sponsorships.length).to.equal(1)
         expect(resultDynamicIds.sponsorships[0].maxOperators).to.equal(3)
         expect(resultDynamicIds.sponsorshipDailyBuckets.length).to.equal(1)
         expect(resultDynamicIds.sponsoringEvents.length).to.equal(2) // sponsoring + slashing
+        expect(resultDynamicIds.nodes.length).to.equal(1)
 
-        expect(resultDynamicIds.stakingEvents.length).to.equal(6)
+        expect(resultDynamicIds.operators.length).to.equal(3)
         expect(resultDynamicIds.operatorDailyBuckets.length).to.equal(3)
         expect(resultDynamicIds.delegations.length).to.equal(3)
-        expect(resultDynamicIds.operators.length).to.equal(3)
-        expect(resultDynamicIds.stakes.length).to.equal(2) // 3 operators - 1 got kicked out
+        expect(resultDynamicIds.stakingEvents.length).to.equal(4) // 3 operators staked + 1 got kicked out
+        expect(resultDynamicIds.stakes.length).to.equal(2) // 3 operators staked - 1 got kicked out
 
         expect(resultDynamicIds.streams.length).to.equal(5)
         expect(resultDynamicIds.streamPermissions.length).to.equal(12) // 3 operators + 9?

--- a/packages/network-subgraphs/schema.graphql
+++ b/packages/network-subgraphs/schema.graphql
@@ -443,6 +443,7 @@ type Stake @entity {
   operator: Operator!
   amountWei: BigInt!
   lockedWei: BigInt!
+  minimumStakeWei: BigInt! # individual minimum stake can be different from global one if operator got flagged or opened lots of flags
   earningsWei: BigInt! # momentary earnings at updateTimestamp
   updateTimestamp: Int! # timestamp when earningsWei (and others) were updated; useful for calculating "real-time" earnings values
   joinTimestamp: Int!

--- a/packages/network-subgraphs/src/sponsorship.ts
+++ b/packages/network-subgraphs/src/sponsorship.ts
@@ -24,10 +24,9 @@ export function handleStakeUpdated(event: StakeUpdate): void {
     let operatorAddress = event.params.operator.toHexString()
     let stakedWei = event.params.stakedWei
     let earningsWei = event.params.earningsWei
-    let lockedStakeWei = event.params.lockedStakeWei
     let now = event.block.timestamp.toU32()
-    log.info('handleStakeUpdated: sponsorship={} operator={} stakedWei={} earningsWei={}, lockedStake={} now={}',
-        [sponsorshipAddress, operatorAddress, stakedWei.toString(), earningsWei.toString(), lockedStakeWei.toString(), now.toString()])
+    log.info('handleStakeUpdated: sponsorship={} operator={} stakedWei={} earningsWei={}, now={}',
+        [sponsorshipAddress, operatorAddress, stakedWei.toString(), earningsWei.toString(), now.toString()])
 
     let stake = loadOrCreateStake(sponsorshipAddress, operatorAddress)
     if (stakedWei == BigInt.zero()) {
@@ -38,7 +37,6 @@ export function handleStakeUpdated(event: StakeUpdate): void {
     stake.updateTimestamp = now
     stake.amountWei = stakedWei
     stake.earningsWei = earningsWei
-    stake.lockedWei = lockedStakeWei
     stake.save()
 
     // also save StakingEvent, TODO: do we need them?
@@ -48,6 +46,20 @@ export function handleStakeUpdated(event: StakeUpdate): void {
     stakingEvent.date = event.block.timestamp
     stakingEvent.amount = event.params.stakedWei
     stakingEvent.save()
+}
+
+export function handleStakeLockUpdated(event: StakeLockUpdate): void {
+    let sponsorshipAddress = event.address.toHexString()
+    let operatorAddress = event.params.operator.toHexString()
+    let lockedStakeWei = event.params.lockedStakeWei
+    let minimumStakeWei = event.params.minimumStakeWei
+    log.info('handleStakeLockUpdated: sponsorship={} operator={} lockedStakeWei={} minimumStakeWei={}',
+        [sponsorshipAddress, operatorAddress, lockedStakeWei.toString(), minimumStakeWei.toString()])
+
+    let stake = loadOrCreateStake(sponsorshipAddress, operatorAddress)
+    stake.lockedAmountWei = lockedStakeWei
+    stake.minimumStakeWei = minimumStakeWei
+    stake.save()
 }
 
 export function handleSponsorshipUpdated(event: SponsorshipUpdate): void {
@@ -214,7 +226,16 @@ function loadOrCreateStake(sponsorshipAddress: string, operatorAddress: string):
         stake = new Stake(stakeID)
         stake.sponsorship = sponsorshipAddress
         stake.operator = operatorAddress
-        stake.joinTimestamp = 0 // set this in StakeUpdate
+
+        // set in handleStakeUpdated
+        stake.joinTimestamp = 0
+        stake.updateTimestamp = 0
+        stake.amountWei = BigInt.zero()
+        stake.earningsWei = BigInt.zero()
+
+        // set in handleStakeLockUpdated
+        stake.lockedWei = BigInt.zero()
+        stake.minimumStakeWei = BigInt.zero() // TODO: populate from global minimum stake once we have the network-stats entity
     }
     return stake
 }

--- a/packages/network-subgraphs/src/sponsorship.ts
+++ b/packages/network-subgraphs/src/sponsorship.ts
@@ -2,6 +2,7 @@ import { log, BigInt, BigDecimal, store } from '@graphprotocol/graph-ts'
 
 import {
     StakeUpdate,
+    StakeLockUpdate,
     SponsorshipUpdate,
     FlagUpdate,
     Flagged,
@@ -57,7 +58,7 @@ export function handleStakeLockUpdated(event: StakeLockUpdate): void {
         [sponsorshipAddress, operatorAddress, lockedStakeWei.toString(), minimumStakeWei.toString()])
 
     let stake = loadOrCreateStake(sponsorshipAddress, operatorAddress)
-    stake.lockedAmountWei = lockedStakeWei
+    stake.lockedWei = lockedStakeWei
     stake.minimumStakeWei = minimumStakeWei
     stake.save()
 }

--- a/packages/network-subgraphs/subgraph.yaml
+++ b/packages/network-subgraphs/subgraph.yaml
@@ -226,8 +226,10 @@ templates:
         - name: Sponsorship
           file: ./abis/Sponsorship.json
       eventHandlers:
-          - event: StakeUpdate(indexed address,uint256,uint256,uint256)
+          - event: StakeUpdate(indexed address,uint256,uint256)
             handler: handleStakeUpdated
+          - event: StakeLockUpdate(indexed address,uint256,uint256)
+            handler: handleStakeLockUpdated
           - event: SponsorshipUpdate(uint256,uint256,uint256,bool)
             handler: handleSponsorshipUpdated
           - event: Flagged(indexed address,indexed address,uint256,uint256,string)

--- a/packages/network-subgraphs/subgraph_mumbai.yaml
+++ b/packages/network-subgraphs/subgraph_mumbai.yaml
@@ -226,8 +226,10 @@ templates:
         - name: Sponsorship
           file: ./abis/Sponsorship.json
       eventHandlers:
-          - event: StakeUpdate(indexed address,uint256,uint256,uint256)
+          - event: StakeUpdate(indexed address,uint256,uint256)
             handler: handleStakeUpdated
+          - event: StakeLockUpdate(indexed address,uint256,uint256)
+            handler: handleStakeLockUpdated
           - event: SponsorshipUpdate(uint256,uint256,uint256,bool)
             handler: handleSponsorshipUpdated
           - event: Flagged(indexed address,indexed address,uint256,uint256,string)


### PR DESCRIPTION
now it's as good as it's ever been: it takes into account if the operator has been flagged or not, so it only reserves the "flag-target stake" if the flagging hasn't been done yet.

How is this different from just locking flag-target stake for everyone?
* targetStakeAtRiskWei depends on stakedWei at the time of flagging, can't know in advance
* locked stake is forfeited when leaving. If flag hasn't been opened, that stake shouldn't be lost, so it shouldn't be locked either (though of course we could at leaving check if there's a flag, and unlock stake if not. BUT now the main contract doesn't need to know anything about flags!)

it could be ever so slightly more elegant if locking also would completely go into kickpolicy, but then it'd be a bit awkward at the leaving time (removeoperator) vs reducestake where reducestake needs to take into account future flag while removeoperator should not (so it wouldn't really be transparent to the main contract that has to slash the locked stake... UNLESS there's some kind of onLeave also in kickpolicy ;) would it then be just a kickpolicy anymore?)