### PR TITLE
Add storage node urls to pre-baked image

### DIFF
--- a/packages/docker-dev-chain-init/index.js
+++ b/packages/docker-dev-chain-init/index.js
@@ -702,8 +702,6 @@ async function smartContractInitialization() {
     log(`Deploying OLD UNUSED NodeRegistry contract 2 (storage node registry) to sidechain from ${sidechainWallet.address}`)
     initialNodes = []
     initialMetadata = []
-    initialNodes.push('0xde1112f631486CfC759A50196853011528bC5FA0')
-    initialMetadata.push('{"http": "http://10.200.10.1:8891"}')
     await deployNodeRegistry(sidechainWallet, initialNodes, initialMetadata)
 
     log(`deploy Uniswap2 mainnet`)

--- a/packages/docker-dev-chain-init/index.js
+++ b/packages/docker-dev-chain-init/index.js
@@ -281,7 +281,8 @@ async function deployStreamRegistries() {
     initialNodes = []
     initialMetadata = []
     initialNodes.push('0xde1112f631486CfC759A50196853011528bC5FA0')
-    initialMetadata.push('{"http": "http://10.200.10.1:8891"}')
+    // the "http" is a legacy definition, used only in Brubeck (NET-1251)
+    initialMetadata.push('{"urls":["http://10.200.10.1:8891"],"http":"http://10.200.10.1:8891"}')
     const strDeploy = await ethers.getContractFactory("NodeRegistry", sidechainWalletStreamReg)
     // const strDeploy = await ethers.getContractFactory('NodeRegistry')
     const strDeployTx = await upgrades.deployProxy(strDeploy,

--- a/packages/network-contracts/scripts/deployToLivenet/1_deployContracts.ts
+++ b/packages/network-contracts/scripts/deployToLivenet/1_deployContracts.ts
@@ -166,8 +166,6 @@ async function main() {
     log(`wallet address ${wallet.address}`)
     const initialNodes: string[] = []
     const initialMetadata: string[] = []
-    // initialNodes.push('0xde1112f631486CfC759A50196853011528bC5FA0')
-    // initialMetadata.push('{"http": "http://10.200.10.1:8891/api/v1"}')
     await deployNodeRegistry(initialNodes, initialMetadata)
 
     await deployStreamRegistry()

--- a/packages/network-contracts/src/StreamrEnvDeployer.ts
+++ b/packages/network-contracts/src/StreamrEnvDeployer.ts
@@ -222,7 +222,8 @@ export class StreamrEnvDeployer {
         const initialStorageNodes = []
         const initialStorageMetadata = []
         initialStorageNodes.push("0xde1112f631486CfC759A50196853011528bC5FA0")
-        initialStorageMetadata.push("{\"http\": \"http://10.200.10.1:8891\"}")
+        // the "http" is a legacy definition, used only in Brubeck (NET-1251)
+        initialStorageMetadata.push('{"urls":["http://10.200.10.1:8891"],"http":"http://10.200.10.1:8891"}')
         const nodeRegistry = await nodeRegistryFactory.deploy() as NodeRegistry
         await nodeRegistry.deployed()
         await (await nodeRegistry.initialize(this.adminWallet.address, false, initialStorageNodes, initialStorageMetadata)).wait()

--- a/packages/network-contracts/src/StreamrEnvDeployer.ts
+++ b/packages/network-contracts/src/StreamrEnvDeployer.ts
@@ -223,7 +223,7 @@ export class StreamrEnvDeployer {
         const initialStorageMetadata = []
         initialStorageNodes.push("0xde1112f631486CfC759A50196853011528bC5FA0")
         // the "http" is a legacy definition, used only in Brubeck (NET-1251)
-        initialStorageMetadata.push('{"urls":["http://10.200.10.1:8891"],"http":"http://10.200.10.1:8891"}')
+        initialStorageMetadata.push("{\"urls\":[\"http://10.200.10.1:8891\"],\"http\":\"http://10.200.10.1:8891\"}")
         const nodeRegistry = await nodeRegistryFactory.deploy() as NodeRegistry
         await nodeRegistry.deployed()
         await (await nodeRegistry.initialize(this.adminWallet.address, false, initialStorageNodes, initialStorageMetadata)).wait()


### PR DESCRIPTION
Add `urls` list. In development environment it contains the same info as the deprecated http field (NET-1251), but in production the fields will have different values.

Also removed some unused code related to this functionality.
