### PR TITLE
ETH-759: spotAPY calculation shouldn't care how long there is sponsorship left

### DIFF
--- a/packages/network-subgraphs/src/helpers.ts
+++ b/packages/network-subgraphs/src/helpers.ts
@@ -135,21 +135,20 @@ export function loadOrCreateNetwork(): Network {
     return network
 }
 
-export function loadOrCreateSponsorshipDailyBucket(sponsorshipId: string, timestamp: BigInt): SponsorshipDailyBucket {
+export function loadOrCreateSponsorshipDailyBucket(sponsorship: Sponsorship, timestamp: BigInt): SponsorshipDailyBucket {
     const date = getBucketStartDate(timestamp)
-    const bucketId = sponsorshipId + "-" + date.toString()
+    const bucketId = sponsorship.id + "-" + date.toString()
     let bucket = SponsorshipDailyBucket.load(bucketId)
     if (bucket === null) {
         log.info("loadOrCreateSponsorshipDailyBucket: creating new bucketId={}", [bucketId])
-        const sponsorship = Sponsorship.load(sponsorshipId)
         bucket = new SponsorshipDailyBucket(bucketId)
-        bucket.sponsorship = sponsorshipId
+        bucket.sponsorship = sponsorship.id
         bucket.date = date
-        bucket.projectedInsolvency = sponsorship!.projectedInsolvency
-        bucket.totalStakedWei = sponsorship!.totalStakedWei
-        bucket.remainingWei = sponsorship!.remainingWei
-        bucket.spotAPY = sponsorship!.spotAPY
-        bucket.operatorCount = sponsorship!.operatorCount
+        bucket.projectedInsolvency = sponsorship.projectedInsolvency
+        bucket.totalStakedWei = sponsorship.totalStakedWei
+        bucket.remainingWei = sponsorship.remainingWei
+        bucket.spotAPY = sponsorship.spotAPY
+        bucket.operatorCount = sponsorship.operatorCount
     }
     return bucket
 }

--- a/packages/network-subgraphs/src/sponsorshipFactory.ts
+++ b/packages/network-subgraphs/src/sponsorshipFactory.ts
@@ -49,7 +49,7 @@ export function handleNewSponsorship(event: NewSponsorship): void {
     // start listening to events from the newly created Sponsorship contract
     SponsorshipTemplate.create(event.params.sponsorshipContract)
 
-    const bucket = loadOrCreateSponsorshipDailyBucket(sponsorshipContractAddressString, event.block.timestamp)
+    const bucket = loadOrCreateSponsorshipDailyBucket(sponsorship, event.block.timestamp)
     bucket.save()
 
     const network = loadOrCreateNetwork()


### PR DESCRIPTION
it used to have a "defense" against Sponsorship creator setting basically arbitrary APY with small DATA investment. This doesn't seem like an issue in practice, so removing that special-casing.