### PR TITLE
FRONT-1921: for initial sponsorships, set sponsor to be the sponsorship creator

### DIFF
--- a/packages/network-subgraphs/README.md
+++ b/packages/network-subgraphs/README.md
@@ -45,6 +45,8 @@ can be recreated with the Dockerfile. To do so:
   * Added Delegation.isSelfDelegation, zeroed earliestUndelegationTimestamp for self-delegations
 * v0.0.7
   * Sponsorship APY fix (ETH-759)
+* v0.0.8
+  * Sponsorship initial sponsoring event fix (FRONT-1921)
 
 # Developer notes
 


### PR DESCRIPTION
the tokens come from sponsorshipFactory, but that's maybe not a meaningful "sponsor"

TODO: test this against production, i.e. deploy to Studio, then test manually, and if ok, deploy to production.

Query:
```
{
  sponsoringEvents(
    where: {sponsorship_in: ["0xa5ea814f2f46a5552ed450de93bd87a37fae9881", "0x93ccf5ccb8b56c69b9ee6dbf1da90611cb7dcc0b"]}
  ) {
    amount
    sponsor
    sponsorship {
      id
    }
  }
}
```

current result:
```
{
  "data": {
    "sponsoringEvents": [
      {
        "amount": "150000000000000000000000",
        "sponsor": "0xe195aba9b489ac9502cae8fdf3e2d0f3a3a5a255",
        "sponsorship": {
          "id": "0x93ccf5ccb8b56c69b9ee6dbf1da90611cb7dcc0b"
        }
      },
      {
        "amount": "0",
        "sponsor": "0x820b2f9a15ed45f9802c59d0cc77c22c81755e45",
        "sponsorship": {
          "id": "0x93ccf5ccb8b56c69b9ee6dbf1da90611cb7dcc0b"
        }
      },
      {
        "amount": "175000000000000000000000",
        "sponsor": "0x820b2f9a15ed45f9802c59d0cc77c22c81755e45",
        "sponsorship": {
          "id": "0xa5ea814f2f46a5552ed450de93bd87a37fae9881"
        }
      }
    ]
  }
}
```

expected result after this fix: in 0xa5...81, the sponsorship of 175 is sent from 0xe1...55, not from 0xa5...81