### PR TITLE
ETH-787: setMultipleStreamPermissionsForUserIds

### DIFF
--- a/packages/network-contracts/contracts/StreamRegistry/StreamRegistryV5.sol
+++ b/packages/network-contracts/contracts/StreamRegistry/StreamRegistryV5.sol
@@ -374,6 +374,10 @@ contract StreamRegistryV5 is Initializable, UUPSUpgradeable, ERC2771ContextUpgra
 
     function getAddressKeyForUserId(string memory streamId, bytes calldata user) public view returns (bytes32) {
         uint256 version32Bytes = streamIdToVersion[streamId];
+        // Pad addresses to 32 bytes to remain compatible with getAddressKey function
+        if (user.length == 20) {
+            return keccak256(abi.encodePacked(version32Bytes, bytes12(0), user));
+        }
         return keccak256(abi.encodePacked(version32Bytes, user));
     }
 

--- a/packages/network-contracts/contracts/StreamRegistry/StreamRegistryV5.sol
+++ b/packages/network-contracts/contracts/StreamRegistry/StreamRegistryV5.sol
@@ -344,24 +344,6 @@ contract StreamRegistryV5 is Initializable, UUPSUpgradeable, ERC2771ContextUpgra
         setPermissionsForUser(streamId, address(0), false, false, publishExpiration, subscribeExpiration, false);
     }
 
-    // function transferAllPermissionsToUser(string calldata streamId, address recipient) public {
-    //     Permission memory permSender = streamIdToPermissions[streamId][getAddressKey(streamId, _msgSender())];
-    //     require(permSender.canEdit || permSender.canDelete || permSender.publishExpiration > 0 || permSender.subscribeExpiration > 0 ||
-    //     permSender.canGrant, "error_noPermissionToTransfer");
-    //     Permission memory permRecipient = streamIdToPermissions[streamId][getAddressKey(streamId, recipient)];
-    //     uint256 publishExpiration = permSender.publishExpiration > permRecipient.publishExpiration ? permSender.publishExpiration : permRecipient.publishExpiration;
-    //     uint256 subscribeExpiration = permSender.subscribeExpiration > permRecipient.subscribeExpiration ? permSender.subscribeExpiration : permRecipient.subscribeExpiration;
-    //     _setAllPermissions(streamId, recipient, permSender.canEdit || permRecipient.canEdit, permSender.canDelete || permRecipient.canDelete,
-    //     publishExpiration, subscribeExpiration, permSender.canGrant || permRecipient.canGrant);
-    //     _setAllPermissions(streamId, _msgSender(), false, false, 0, 0, false);
-    // }
-
-    // function transferPermissionToUser(string calldata streamId, address recipient, PermissionType permissionType) public {
-    //     require(hasDirectPermission(streamId, _msgSender(), permissionType), "error_noPermissionToTransfer");
-    //     _setPermission(streamId, _msgSender(), permissionType, false);
-    //     _setPermission(streamId, recipient, permissionType, true);
-    // }
-
     //////////////////////////////////////////////////////////////////////////////////
     // *forUserId functions: replace user as address with user as bytes calldata
     //////////////////////////////////////////////////////////////////////////////////
@@ -376,26 +358,6 @@ contract StreamRegistryV5 is Initializable, UUPSUpgradeable, ERC2771ContextUpgra
         }
         return keccak256(abi.encodePacked(version32Bytes, user));
     }
-
-    // function userIdHasPermission(string calldata streamId, bytes calldata user, PermissionType permissionType) public view returns (bool userHasPermission) {
-    //     return userIdHasDirectPermission(streamId, user, permissionType) || hasDirectPermission(streamId, address(0), permissionType);
-    // }
-
-    // function userIdHasDirectPermission(string calldata streamId, bytes calldata user, PermissionType permissionType) public view returns (bool userHasPermission) {
-    //     bytes32 key = getAddressKeyForUserId(streamId, user);
-    //     Permission storage p = streamIdToPermissions[streamId][key];
-    //     if (permissionType == PermissionType.Edit) {
-    //         return p.canEdit;
-    //     } else if (permissionType == PermissionType.Delete) {
-    //         return p.canDelete;
-    //     } else if (permissionType == PermissionType.Publish) {
-    //         return p.publishExpiration >= block.timestamp;
-    //     } else if (permissionType == PermissionType.Subscribe) {
-    //         return p.subscribeExpiration >= block.timestamp;
-    //     } else if (permissionType == PermissionType.Grant) {
-    //         return p.canGrant;
-    //     }
-    // }
 
     function grantPermissionForUserId(string calldata streamId, bytes calldata user, PermissionType permissionType) public hasGrantPermission(streamId) {
         bytes32 userKey = getAddressKeyForUserId(streamId, user);
@@ -414,14 +376,6 @@ contract StreamRegistryV5 is Initializable, UUPSUpgradeable, ERC2771ContextUpgra
         emit PermissionUpdatedForUserId(streamId, user, false, false, 0, 0, false);
     }
 
-
-    // function createStreamWithPermissionsForUserIds(
-    //     string calldata streamIdPath, string calldata metadataJsonString, bytes[] calldata users, Permission[] calldata permissions
-    // ) public {
-    //     string memory ownerstring = addressToString(_msgSender());
-    //     string memory streamId = _createStreamAndPermission(_msgSender(), ownerstring, streamIdPath, metadataJsonString);
-    //     _setPermissionsForUserIds(streamId, users, permissions);
-    // }
     function setExpirationTimeForUserId(
         string calldata streamId, bytes calldata user, PermissionType permissionType, uint256 expirationTime
     ) public hasGrantPermission(streamId) {
@@ -448,44 +402,13 @@ contract StreamRegistryV5 is Initializable, UUPSUpgradeable, ERC2771ContextUpgra
         }
     }
 
+    // NOTE: commented out due to size concerns, can be done via setPermissionsForUserIds
     // function setPermissionsForUserId(
     //     string calldata streamId, bytes calldata user, bool canEdit, bool deletePerm, uint256 publishExpiration, uint256 subscribeExpiration, bool canGrant
     // ) public hasGrantPermission(streamId) {
-    //     _setPermissionsForUserId(streamId, user, canEdit, deletePerm, publishExpiration, subscribeExpiration, canGrant);
-    // }
-
-    // function _setPermissionsForUserId(
-    //     string memory streamId, bytes calldata user, bool canEdit, bool deletePerm, uint256 publishExpiration, uint256 subscribeExpiration, bool canGrant
-    // ) private {
     //     bytes32 userKey = getAddressKeyForUserId(streamId, user);
-    //     if (!canEdit && !deletePerm && !canGrant && publishExpiration < block.timestamp && subscribeExpiration < block.timestamp) {
-    //         delete streamIdToPermissions[streamId][userKey];
-    //     } else {
-    //         Permission storage p = streamIdToPermissions[streamId][userKey];
-    //         p.canEdit = canEdit;
-    //         p.canDelete = deletePerm;
-    //         p.publishExpiration = publishExpiration;
-    //         p.subscribeExpiration = subscribeExpiration;
-    //         p.canGrant = canGrant;
-    //     }
+    //     _setAllPermissions(streamId, userKey, canEdit, deletePerm, publishExpiration, subscribeExpiration, canGrant);
     //     emit PermissionUpdatedForUserId(streamId, user, canEdit, deletePerm, publishExpiration, subscribeExpiration, canGrant);
-    // }
-
-    // function transferAllPermissionsToUserId(string calldata streamId, bytes calldata recipient) public {
-    //     Permission memory permSender = streamIdToPermissions[streamId][getAddressKey(streamId, _msgSender())];
-    //     require(permSender.canEdit || permSender.canDelete || permSender.publishExpiration > 0 || permSender.subscribeExpiration > 0 || permSender.canGrant, "error_noPermissionToTransfer");
-    //     Permission memory permRecipient = streamIdToPermissions[streamId][getAddressKeyForUserId(streamId, recipient)];
-    //     uint256 publishExpiration = permSender.publishExpiration > permRecipient.publishExpiration ? permSender.publishExpiration : permRecipient.publishExpiration;
-    //     uint256 subscribeExpiration = permSender.subscribeExpiration > permRecipient.subscribeExpiration ? permSender.subscribeExpiration : permRecipient.subscribeExpiration;
-    //     _setPermissionsForUserId(streamId, recipient, permSender.canEdit || permRecipient.canEdit, permSender.canDelete || permRecipient.canDelete,
-    //     publishExpiration, subscribeExpiration, permSender.canGrant || permRecipient.canGrant);
-    //     _setAllPermissions(streamId, _msgSender(), false, false, 0, 0, false);
-    // }
-
-    // function transferPermissionToUserId(string calldata streamId, bytes calldata recipient, PermissionType permissionType) public {
-    //     require(hasDirectPermission(streamId, _msgSender(), permissionType), "error_noPermissionToTransfer");
-    //     _setPermission(streamId, _msgSender(), permissionType, false);
-    //     _setPermissionForUserId(streamId, recipient, permissionType, true);
     // }
 
     /**
@@ -493,7 +416,7 @@ contract StreamRegistryV5 is Initializable, UUPSUpgradeable, ERC2771ContextUpgra
      * For publish/subscribe expiration, if public permission has a longer validity, use that.
      **/
     function getPermissionsForUserId(string calldata streamId, bytes calldata user) public view streamExists(streamId) returns (Permission memory permission) {
-        return _getPermissionsForUser(streamId, getAddressKeyForUserId(streamId, user)); // TODO don't cast streamId calldata->memory
+        return _getPermissionsForUser(streamId, getAddressKeyForUserId(streamId, user));
     }
     function _getPermissionsForUser(string calldata streamId, bytes32 userKey) private view returns (Permission memory permission) {
         permission = streamIdToPermissions[streamId][userKey];

--- a/packages/network-contracts/contracts/StreamRegistry/StreamRegistryV5.sol
+++ b/packages/network-contracts/contracts/StreamRegistry/StreamRegistryV5.sol
@@ -185,15 +185,7 @@ contract StreamRegistryV5 is Initializable, UUPSUpgradeable, ERC2771ContextUpgra
      * For publish/subscribe expiration, if public permission has a longer validity, use that.
      **/
     function getPermissionsForUser(string calldata streamId, address user) public view streamExists(streamId) returns (Permission memory permission) {
-        permission = streamIdToPermissions[streamId][getAddressKey(streamId, user)];
-        Permission memory publicPermission = streamIdToPermissions[streamId][getAddressKey(streamId, address(0))];
-        if (permission.publishExpiration < block.timestamp && publicPermission.publishExpiration >= block.timestamp) {
-            permission.publishExpiration = publicPermission.publishExpiration;
-        }
-        if (permission.subscribeExpiration < block.timestamp && publicPermission.subscribeExpiration >= block.timestamp) {
-            permission.subscribeExpiration = publicPermission.subscribeExpiration;
-        }
-        return permission;
+        return _getPermissionsForUser(streamId, getAddressKey(streamId, user));
     }
 
     function getDirectPermissionsForUser(string calldata streamId, address user) public view streamExists(streamId) returns (Permission memory permission) {
@@ -505,7 +497,10 @@ contract StreamRegistryV5 is Initializable, UUPSUpgradeable, ERC2771ContextUpgra
      * For publish/subscribe expiration, if public permission has a longer validity, use that.
      **/
     function getPermissionsForUserId(string calldata streamId, bytes calldata user) public view streamExists(streamId) returns (Permission memory permission) {
-        permission = streamIdToPermissions[streamId][getAddressKeyForUserId(streamId, user)];
+        return _getPermissionsForUser(streamId, getAddressKeyForUserId(streamId, user)); // TODO don't cast streamId calldata->memory
+    }
+    function _getPermissionsForUser(string calldata streamId, bytes32 userKey) public view streamExists(streamId) returns (Permission memory permission) {
+        permission = streamIdToPermissions[streamId][userKey];
         Permission memory publicPermission = streamIdToPermissions[streamId][getAddressKey(streamId, address(0))];
         if (permission.publishExpiration < block.timestamp && publicPermission.publishExpiration >= block.timestamp) {
             permission.publishExpiration = publicPermission.publishExpiration;

--- a/packages/network-contracts/contracts/StreamRegistry/StreamRegistryV5.sol
+++ b/packages/network-contracts/contracts/StreamRegistry/StreamRegistryV5.sol
@@ -352,11 +352,8 @@ contract StreamRegistryV5 is Initializable, UUPSUpgradeable, ERC2771ContextUpgra
 
     function getAddressKeyForUserId(string calldata streamId, bytes calldata user) public view returns (bytes32) {
         uint256 version32Bytes = streamIdToVersion[streamId];
-        // Pad addresses to 32 bytes to remain compatible with getAddressKey function
-        if (user.length == 20) {
-            return keccak256(abi.encodePacked(version32Bytes, bytes12(0), user));
-        }
-        return keccak256(abi.encodePacked(version32Bytes, user));
+        // Add the correct padding so that 20-byte addresses to become padded to 32 bytes, to remain compatible with getAddressKey function that uses abi.encode
+        return keccak256(abi.encodePacked(version32Bytes, bytes12(0), user));
     }
 
     function grantPermissionForUserId(string calldata streamId, bytes calldata user, PermissionType permissionType) public hasGrantPermission(streamId) {

--- a/packages/network-contracts/contracts/StreamRegistry/StreamRegistryV5.sol
+++ b/packages/network-contracts/contracts/StreamRegistry/StreamRegistryV5.sol
@@ -254,7 +254,7 @@ contract StreamRegistryV5 is Initializable, UUPSUpgradeable, ERC2771ContextUpgra
         }
     }
 
-    function setPermissions(string calldata streamId, address[] calldata users, Permission[] calldata permissions) public hasGrantPermission(streamId) {
+    function setPermissions(string calldata streamId, address[] calldata users, Permission[] calldata permissions) external hasGrantPermission(streamId) {
         _setPermissionsBatch(streamId, users, permissions);
     }
 
@@ -273,7 +273,7 @@ contract StreamRegistryV5 is Initializable, UUPSUpgradeable, ERC2771ContextUpgra
         require(users.length == permissions.length && permissions.length == streamIds.length, "error_invalidInputArrayLengths");
         uint arrayLength = streamIds.length;
         for (uint i=0; i<arrayLength; i++) {
-            setPermissions(streamIds[i], users[i], permissions[i]);
+            _setPermissionsBatch(streamIds[i], users[i], permissions[i]);
         }
     }
 

--- a/packages/network-contracts/contracts/StreamRegistry/StreamRegistryV5.sol
+++ b/packages/network-contracts/contracts/StreamRegistry/StreamRegistryV5.sol
@@ -364,7 +364,7 @@ contract StreamRegistryV5 is Initializable, UUPSUpgradeable, ERC2771ContextUpgra
 
     event PermissionUpdatedForUserId(string streamId, bytes user, bool canEdit, bool canDelete, uint256 publishExpiration, uint256 subscribeExpiration, bool canGrant);
 
-    function getAddressKeyForUserId(string memory streamId, bytes calldata user) public view returns (bytes32) {
+    function getAddressKeyForUserId(string calldata streamId, bytes calldata user) public view returns (bytes32) {
         uint256 version32Bytes = streamIdToVersion[streamId];
         // Pad addresses to 32 bytes to remain compatible with getAddressKey function
         if (user.length == 20) {
@@ -499,7 +499,7 @@ contract StreamRegistryV5 is Initializable, UUPSUpgradeable, ERC2771ContextUpgra
     function getPermissionsForUserId(string calldata streamId, bytes calldata user) public view streamExists(streamId) returns (Permission memory permission) {
         return _getPermissionsForUser(streamId, getAddressKeyForUserId(streamId, user)); // TODO don't cast streamId calldata->memory
     }
-    function _getPermissionsForUser(string calldata streamId, bytes32 userKey) public view streamExists(streamId) returns (Permission memory permission) {
+    function _getPermissionsForUser(string calldata streamId, bytes32 userKey) private view returns (Permission memory permission) {
         permission = streamIdToPermissions[streamId][userKey];
         Permission memory publicPermission = streamIdToPermissions[streamId][getAddressKey(streamId, address(0))];
         if (permission.publishExpiration < block.timestamp && publicPermission.publishExpiration >= block.timestamp) {

--- a/packages/network-contracts/contracts/StreamRegistry/StreamRegistryV5.sol
+++ b/packages/network-contracts/contracts/StreamRegistry/StreamRegistryV5.sol
@@ -6,7 +6,8 @@
  *   - this is to support permission targets longer than 20 bytes (different cryptography)
  *   - due to size concerns:
  *      - userIdHasPermission and userIdHasDirectPermission are not included in V5
- *      - setExpirationTimeForUserId not included
+ *      - createStreamWithPermissionsForUserIds, setExpirationTimeForUserId, setPermissionsForUserId not included
+ *      - transferPermissionToUserId, transferAllPermissionsToUserId not included
  *      - combined some internal functions to take userKey instead of address or bytes id
  * - Removed little used functions: transferAllPermissionsToUser, transferPermissionToUser
  */
@@ -446,13 +447,14 @@ contract StreamRegistryV5 is Initializable, UUPSUpgradeable, ERC2771ContextUpgra
             emit PermissionUpdatedForUserId(streamId, users[i], p.canEdit, p.canDelete, p.publishExpiration, p.subscribeExpiration, p.canGrant);
         }
     }
-    // function setMultipleStreamPermissionsForUserIds(string[] calldata streamIds, bytes[][] calldata users, Permission[][] calldata permissions) public {
-    //     require(users.length == permissions.length && permissions.length == streamIds.length, "error_invalidInputArrayLengths");
-    //     uint arrayLength = streamIds.length;
-    //     for (uint i = 0; i < arrayLength; i++) {
-    //         setPermissionsForUserIds(streamIds[i], users[i], permissions[i]);
-    //     }
-    // }
+
+    function setMultipleStreamPermissionsForUserIds(string[] calldata streamIds, bytes[][] calldata users, Permission[][] calldata permissions) public {
+        require(users.length == permissions.length && permissions.length == streamIds.length, "error_invalidInputArrayLengths");
+        uint arrayLength = streamIds.length;
+        for (uint i = 0; i < arrayLength; i++) {
+            setPermissionsForUserIds(streamIds[i], users[i], permissions[i]);
+        }
+    }
 
     // function setPermissionsForUserId(
     //     string calldata streamId, bytes calldata user, bool canEdit, bool deletePerm, uint256 publishExpiration, uint256 subscribeExpiration, bool canGrant

--- a/packages/network-contracts/test/hardhat/Registries/StreamRegistry.test.ts
+++ b/packages/network-contracts/test/hardhat/Registries/StreamRegistry.test.ts
@@ -50,7 +50,7 @@ const getBlocktime = async (): Promise<number> => {
     return block.timestamp
 }
 
-describe.only("StreamRegistry", async (): Promise<void> => {
+describe("StreamRegistry", async (): Promise<void> => {
     let wallets: WalletType[]
     let registry: StreamRegistry
     let registryFromUser0: StreamRegistry

--- a/packages/network-contracts/test/hardhat/Registries/StreamRegistry.test.ts
+++ b/packages/network-contracts/test/hardhat/Registries/StreamRegistry.test.ts
@@ -14,7 +14,6 @@ const log = Debug("Streamr::test::StreamRegistry")
 const {
     Wallet,
     BigNumber,
-    utils: { hexZeroPad },
     constants: { AddressZero }
 } = ethers
 
@@ -44,7 +43,7 @@ const getBlocktime = async (): Promise<number> => {
     return block.timestamp
 }
 
-describe("StreamRegistry", async (): Promise<void> => {
+describe.only("StreamRegistry", async (): Promise<void> => {
     let wallets: WalletType[]
     // let ensCacheFromAdmin: ENSCache
     let registry: StreamRegistry
@@ -737,13 +736,13 @@ describe("StreamRegistry", async (): Promise<void> => {
         //         .to.emit(registry, "PermissionUpdatedForUserId").withArgs(streamId, userBytesId + "01", false, false, MAX_INT, MAX_INT, false)
         // })
 
-        // it("setMultipleStreamPermissionsForUserIds happy path", async (): Promise<void> => {
-        //     const streamId = await createStream()
-        //     const perms = { ...zeroPermissionStruct, subscribeExpiration: MAX_INT }
-        //     await expect(registry.setMultipleStreamPermissionsForUserIds([streamId, streamId], [[userBytesId], [userBytesId]], [[perms], [perms]]))
-        //         .to.emit(registry, "PermissionUpdatedForUserId").withArgs(streamId, userBytesId, false, false, ZERO, MAX_INT, false)
-        //         .to.emit(registry, "PermissionUpdatedForUserId").withArgs(streamId, userBytesId, false, false, ZERO, MAX_INT, false)
-        // })
+        it("setMultipleStreamPermissionsForUserIds happy path", async (): Promise<void> => {
+            const streamId = await createStream()
+            const perms = { ...zeroPermissionStruct, subscribeExpiration: MAX_INT }
+            await expect(registry.setMultipleStreamPermissionsForUserIds([streamId, streamId], [[userBytesId], [userBytesId]], [[perms], [perms]]))
+                .to.emit(registry, "PermissionUpdatedForUserId").withArgs(streamId, userBytesId, false, false, ZERO, MAX_INT, false)
+                .to.emit(registry, "PermissionUpdatedForUserId").withArgs(streamId, userBytesId, false, false, ZERO, MAX_INT, false)
+        })
 
         it("setPermissionsForUserIds happy path", async (): Promise<void> => {
             const streamId = await createStream()
@@ -781,57 +780,56 @@ describe("StreamRegistry", async (): Promise<void> => {
                 .to.be.revertedWith("error_noSharePermission")
         })
 
-        // it("setMultiplePermissionsForUserIds FAILS for non-existent stream / no grantperm / arg-length mismatch", async (): Promise<void> => {
-        //     const perms = { ...zeroPermissionStruct, subscribeExpiration: MAX_INT }
-        //     await expect(registry.setMultipleStreamPermissionsForUserIds(
-        //         [streamId1, "0x00"],
-        //         [[userBytesId], [userBytesId]],
-        //         [[perms], [perms]])
-        //     ).to.be.revertedWith("error_streamDoesNotExist")
-        //     await expect(registryFromUser1.setMultipleStreamPermissionsForUserIds(
-        //         [streamId1, "0x00"],
-        //         [[userBytesId], [userBytesId]],
-        //         [[perms], [perms]])
-        //     ).to.be.revertedWith("error_noSharePermission")
-        //     await expect(registry.setMultipleStreamPermissionsForUserIds(
-        //         [streamId1],
-        //         [[userBytesId], [userBytesId]],
-        //         [[perms], [perms]])
-        //     ).to.be.revertedWith("error_invalidInputArrayLengths")
-        //     await expect(registry.setMultipleStreamPermissionsForUserIds(
-        //         [streamId1, streamId1],
-        //         [[userBytesId]],
-        //         [[perms], [perms]])
-        //     ).to.be.revertedWith("error_invalidInputArrayLengths")
-        //     await expect(registry.setMultipleStreamPermissionsForUserIds(
-        //         [streamId1, streamId1],
-        //         [[userBytesId], [userBytesId]],
-        //         [[perms]])
-        //     ).to.be.revertedWith("error_invalidInputArrayLengths")
-        //     await expect(registry.setMultipleStreamPermissionsForUserIds(
-        //         [streamId1, streamId1],
-        //         [[userBytesId, userBytesId], [userBytesId]],
-        //         [[perms], [perms]])
-        //     ).to.be.revertedWith("error_invalidInputArrayLengths")
-        //     await expect(registry.setMultipleStreamPermissionsForUserIds(
-        //         [streamId1, streamId1],
-        //         [[userBytesId], [userBytesId]],
-        //         [[perms], [perms, perms]])
-        //     ).to.be.revertedWith("error_invalidInputArrayLengths")
-        // })
+        it("setMultipleStreamPermissionsForUserIds FAILS for non-existent stream / no grantperm / arg-length mismatch", async (): Promise<void> => {
+            const perms = { ...zeroPermissionStruct, subscribeExpiration: MAX_INT }
+            await expect(registry.setMultipleStreamPermissionsForUserIds(
+                [streamId1, "0x00"],
+                [[userBytesId], [userBytesId]],
+                [[perms], [perms]])
+            ).to.be.revertedWith("error_streamDoesNotExist")
+            await expect(registryFromUser1.setMultipleStreamPermissionsForUserIds(
+                [streamId1, "0x00"],
+                [[userBytesId], [userBytesId]],
+                [[perms], [perms]])
+            ).to.be.revertedWith("error_noSharePermission")
+            await expect(registry.setMultipleStreamPermissionsForUserIds(
+                [streamId1],
+                [[userBytesId], [userBytesId]],
+                [[perms], [perms]])
+            ).to.be.revertedWith("error_invalidInputArrayLengths")
+            await expect(registry.setMultipleStreamPermissionsForUserIds(
+                [streamId1, streamId1],
+                [[userBytesId]],
+                [[perms], [perms]])
+            ).to.be.revertedWith("error_invalidInputArrayLengths")
+            await expect(registry.setMultipleStreamPermissionsForUserIds(
+                [streamId1, streamId1],
+                [[userBytesId], [userBytesId]],
+                [[perms]])
+            ).to.be.revertedWith("error_invalidInputArrayLengths")
+            await expect(registry.setMultipleStreamPermissionsForUserIds(
+                [streamId1, streamId1],
+                [[userBytesId, userBytesId], [userBytesId]],
+                [[perms], [perms]])
+            ).to.be.revertedWith("error_invalidInputArrayLengths")
+            await expect(registry.setMultipleStreamPermissionsForUserIds(
+                [streamId1, streamId1],
+                [[userBytesId], [userBytesId]],
+                [[perms], [perms, perms]])
+            ).to.be.revertedWith("error_invalidInputArrayLengths")
+        })
 
         it("should work with addresses just like non-bytes-id functions", async (): Promise<void> => {
             const streamId = await createStream()
-            const user0BytesId = hexZeroPad(user0Address, 32)
-            expect(await registry.getPermissionsForUserId(streamId, user0BytesId)).to.deep.equal([false, false, ZERO, ZERO, false])
+            expect(await registry.getPermissionsForUserId(streamId, user0Address)).to.deep.equal([false, false, ZERO, ZERO, false])
             await (await registry.grantPermission(streamId, user0Address, PermissionType.Publish)).wait()
-            expect(await registry.getPermissionsForUserId(streamId, user0BytesId)).to.deep.equal([false, false, MAX_INT, ZERO, false])
-            await (await registry.revokeAllPermissionsForUserId(streamId, user0BytesId)).wait()
+            expect(await registry.getPermissionsForUserId(streamId, user0Address)).to.deep.equal([false, false, MAX_INT, ZERO, false])
+            await (await registry.revokeAllPermissionsForUserId(streamId, user0Address)).wait()
             expect(await registry.getPermissionsForUser(streamId, user0Address)).to.deep.equal([false, false, ZERO, ZERO, false])
-            await (await registry.grantPermissionForUserId(streamId, user0BytesId, PermissionType.Subscribe)).wait()
+            await (await registry.grantPermissionForUserId(streamId, user0Address, PermissionType.Subscribe)).wait()
             expect(await registry.getPermissionsForUser(streamId, user0Address)).to.deep.equal([false, false, ZERO, MAX_INT, false])
             await (await registry.revokeAllPermissionsForUser(streamId, user0Address)).wait()
-            expect(await registry.getPermissionsForUserId(streamId, user0BytesId)).to.deep.equal([false, false, ZERO, ZERO, false])
+            expect(await registry.getPermissionsForUserId(streamId, user0Address)).to.deep.equal([false, false, ZERO, ZERO, false])
         })
     })
 
@@ -905,223 +903,6 @@ describe("StreamRegistry", async (): Promise<void> => {
                 .to.equal([false, false, ZERO, ZERO, false].toString())
         })
     })
-
-    // removed from V5
-    describe("Trusted setters", () => {
-        it("positivetest grantRole, revokerole", async (): Promise<void> => {
-            await registry.grantRole(await registry.TRUSTED_ROLE(), adminAddress)
-            expect(await registry.hasRole(await registry.TRUSTED_ROLE(), adminAddress))
-                .to.equal(true)
-            await registry.revokeRole(await registry.TRUSTED_ROLE(), adminAddress)
-            expect(await registry.hasRole(await registry.TRUSTED_ROLE(), adminAddress))
-                .to.equal(false)
-        })
-
-        it("negativetest grantRole, revokerole", async (): Promise<void> => {
-            await expect(registryFromUser0.grantRole(await registry.TRUSTED_ROLE(), user0Address))
-                .to.be.revertedWith("AccessControl: account 0x70997970c51812dc3a010c7d01b50e0d17dc79c8 is missing "
-                + "role 0x0000000000000000000000000000000000000000000000000000000000000000")
-        })
-
-        // // negativetest setPublicPermission is trivial, was tested in setPermissionsForUser negativetest
-        // it("positivetest trustedRoleSetStream", async (): Promise<void> => {
-        //     expect((await registry.getPermissionsForUser(streamId0, trustedAddress)).toString())
-        //         .to.equal([false, false, ZERO, ZERO, false].toString())
-        //     expect(await registry.getStreamMetadata(streamId0))
-        //         .to.deep.equal(metadata0)
-        //     await registryFromMigrator.trustedSetStreamMetadata(streamId0, metadata1)
-        //     expect(await registry.getStreamMetadata(streamId0))
-        //         .to.deep.equal(metadata1)
-        // })
-
-        // it("positivetest getTrustedRoleId", async (): Promise<void> => {
-        //     expect(await registryFromAdmin.getTrustedRole()).to.equal("0x2de84d9fbdf6d06e2cc584295043dbd76046423b9f8bae9426d4fa5e7c03f4a7")
-        // })
-
-        // it("positivetest trustedRoleSetPermissionsForUser", async (): Promise<void> => {
-        //     expect((await registry.getPermissionsForUser(streamId0, trustedAddress)).toString())
-        //         .to.equal([false, false, ZERO, ZERO, false].toString())
-        //     expect((await registry.getPermissionsForUser(streamId0, user0Address)).toString())
-        //         .to.equal([false, false, ZERO, ZERO, false].toString())
-        //     await registryFromMigrator.trustedSetPermissionsForUser(streamId0, user0Address,
-        //         true, true, MAX_INT, MAX_INT, true)
-        //     expect((await registry.getPermissionsForUser(streamId0, user0Address)).toString())
-        //         .to.equal([true, true, MAX_INT, MAX_INT, true].toString())
-        // })
-
-        // it("negativetest trustedSetStream", async (): Promise<void> => {
-        //     await expect(registryFromAdmin.trustedSetStreamMetadata(streamId0, metadata1))
-        //         .to.be.revertedWith("error_mustBeTrustedRole")
-        // })
-
-        // it("positivetest trustedSetStreamWithPermissions", async (): Promise<void> => {
-        //     expect((await registry.getPermissionsForUser(streamId0, user0Address)).toString())
-        //         .to.equal([true, true, MAX_INT, MAX_INT, true].toString())
-        //     expect(await registry.getStreamMetadata(streamId0))
-        //         .to.deep.equal(metadata1)
-        //     await registryFromMigrator.trustedSetStreamWithPermission(streamId0, metadata0, user0Address, false, false, 0, 0, false)
-        //     expect(await registry.getStreamMetadata(streamId0))
-        //         .to.deep.equal(metadata0)
-        //     expect((await registry.getPermissionsForUser(streamId0, user0Address)).toString())
-        //         .to.equal([false, false, ZERO, ZERO, false].toString())
-        //     await registryFromMigrator.trustedSetStreamWithPermission(streamId0, metadata1, user0Address, true, true, MAX_INT, MAX_INT, true)
-        //     expect(await registry.getStreamMetadata(streamId0))
-        //         .to.deep.equal(metadata1)
-        //     expect((await registry.getPermissionsForUser(streamId0, user0Address)).toString())
-        //         .to.equal([true, true, MAX_INT, MAX_INT, true].toString())
-        // })
-
-        // it("negativetest trustedSetPermissionsForUser", async (): Promise<void> => {
-        //     await expect(registryFromAdmin.trustedSetPermissionsForUser(streamId0,
-        //         user0Address, true, true, MAX_INT, MAX_INT, true))
-        //         .to.be.revertedWith("error_mustBeTrustedRole")
-        // })
-
-        // it("positiveTest trustedSetStreams", async (): Promise<void> => {
-        //     const STREAMS_TO_MIGRATE = 50
-        //     const streamIds: string[] = []
-        //     const users: string[] = []
-        //     const metadatas: string[] = []
-        //     const permissions = []
-        //     for (let i = 0; i < STREAMS_TO_MIGRATE; i++) {
-        //         const user = Wallet.createRandom()
-        //         streamIds.push(`${user.address}/streamidbulkmigrate/id${i}`)
-        //         users.push(user.address)
-        //         metadatas.push(`metadata-${i}`)
-        //         permissions.push({
-        //             canEdit: true,
-        //             canDelete: true,
-        //             publishExpiration: MAX_INT,
-        //             subscribeExpiration: MAX_INT,
-        //             canGrant: true
-        //         })
-        //     }
-        //     await registryFromMigrator.trustedSetStreams(streamIds, users, metadatas, permissions)
-        //     for (let i = 0; i < STREAMS_TO_MIGRATE; i++) {
-        //         expect(await registry.getStreamMetadata(streamIds[i])).to.equal(metadatas[i])
-        //     }
-        // })
-
-        // it("positiveTest trustedSetPermissions", async (): Promise<void> => {
-        //     const STREAMS_TO_MIGRATE = 50
-        //     const streamIds: string[] = []
-        //     const users: string[] = []
-        //     const metadatas: string[] = []
-        //     const permissions = []
-        //     for (let i = 0; i < STREAMS_TO_MIGRATE; i++) {
-        //         const user = Wallet.createRandom()
-        //         streamIds.push(`${user.address}/streamidbulkmigrate/id${i}`)
-        //         users.push(user.address)
-        //         metadatas.push(`metadata-${i}`)
-        //         permissions.push({
-        //             canEdit: true,
-        //             canDelete: true,
-        //             publishExpiration: MAX_INT,
-        //             subscribeExpiration: MAX_INT,
-        //             canGrant: true
-        //         })
-        //     }
-        //     await registryFromMigrator.trustedCreateStreams(streamIds, metadatas)
-        //     await registryFromMigrator.trustedSetPermissions(streamIds, users, permissions)
-        //     for (let i = 0; i < STREAMS_TO_MIGRATE; i++) {
-        //         expect(await registry.getStreamMetadata(streamIds[i])).to.equal(metadatas[i])
-        //     }
-        // })
-
-        // it("negativetest trustedSetPermissions", async (): Promise<void> => {
-        //     const permissions = {
-        //         canEdit: true,
-        //         canDelete: true,
-        //         publishExpiration: MAX_INT,
-        //         subscribeExpiration: MAX_INT,
-        //         canGrant: true
-        //     }
-        //     await expect(registryFromUser0.trustedCreateStreams([`${user0Address}/test`], ["meta"]))
-        //         .to.be.revertedWith("error_mustBeTrustedRole")
-        //     await expect(registryFromUser0.trustedSetPermissions([`${user0Address}/test`], [user0Address], [permissions]))
-        //         .to.be.revertedWith("error_mustBeTrustedRole")
-        // })
-    })
-
-    // removed in V5
-    // describe("Transfer permissions", () => {
-    //     it("positivetest transferAllPermissionsToUser", async (): Promise<void> => {
-    //         const streamId = await createStream()
-    //         await registry.setPermissionsForUser(streamId, user0Address, true, true, 0, 0, true)
-
-    //         expect((await registry.getPermissionsForUser(streamId, adminAddress)).toString())
-    //             .to.equal([true, true, MAX_INT, MAX_INT, true].toString())
-    //         expect((await registry.getPermissionsForUser(streamId, user1Address)).toString())
-    //             .to.equal([false, false, ZERO, ZERO, false].toString())
-    //         await registry.transferAllPermissionsToUser(streamId, user1Address)
-    //         expect((await registry.getPermissionsForUser(streamId, adminAddress)).toString())
-    //             .to.equal([false, false, ZERO, ZERO, false].toString())
-    //         expect((await registry.getPermissionsForUser(streamId, user1Address)).toString())
-    //             .to.equal([true, true, MAX_INT, MAX_INT, true].toString())
-
-    //         // make sure positive ones are not overwritten
-    //         // user 0 and 1 both have all perms
-    //         await registryFromUser0.setPermissionsForUser(streamId, user0Address, true, false, 0, 0, false)
-    //         // it also tests that user0 can transfer away even though he does not have share permission
-    //         await registryFromUser0.transferAllPermissionsToUser(streamId, user1Address)
-    //         expect((await registry.getPermissionsForUser(streamId, user0Address)).toString())
-    //             .to.equal([false, false, ZERO, ZERO, false].toString())
-    //         expect((await registry.getPermissionsForUser(streamId, user1Address)).toString())
-    //             .to.equal([true, true, MAX_INT, MAX_INT, true].toString())
-    //     })
-
-    //     it("negativetest transferAllPermissionsToUser", async (): Promise<void> => {
-    //         await expect(registryFromUser0.transferAllPermissionsToUser(streamId0, user1Address))
-    //             .to.be.revertedWith("error_noPermissionToTransfer")
-    //     })
-
-    //     it("positivetest transferPermissionToUser", async (): Promise<void> => {
-    //         await registry.setPermissionsForUser(streamId0, user1Address, true, true, MAX_INT, MAX_INT, true)
-
-    //         expect((await registry.getPermissionsForUser(streamId0, user1Address)).toString())
-    //             .to.equal([true, true, MAX_INT, MAX_INT, true].toString())
-    //         expect((await registry.getPermissionsForUser(streamId0, user0Address)).toString())
-    //             .to.equal([false, false, ZERO, ZERO, false].toString())
-    //         await registryFromUser1.transferPermissionToUser(streamId0, user0Address, PermissionType.Edit)
-    //         expect((await registry.getPermissionsForUser(streamId0, user1Address)).toString())
-    //             .to.equal([false, true, MAX_INT, MAX_INT, true].toString())
-    //         expect((await registry.getPermissionsForUser(streamId0, user0Address)).toString())
-    //             .to.equal([true, false, ZERO, ZERO, false].toString())
-    //         await registryFromUser1.transferPermissionToUser(streamId0, user0Address, PermissionType.Delete)
-    //         expect((await registry.getPermissionsForUser(streamId0, user1Address)).toString())
-    //             .to.equal([false, false, MAX_INT, MAX_INT, true].toString())
-    //         expect((await registry.getPermissionsForUser(streamId0, user0Address)).toString())
-    //             .to.equal([true, true, ZERO, ZERO, false].toString())
-    //         await registryFromUser1.transferPermissionToUser(streamId0, user0Address, PermissionType.Publish)
-    //         expect((await registry.getPermissionsForUser(streamId0, user1Address)).toString())
-    //             .to.equal([false, false, ZERO, MAX_INT, true].toString())
-    //         expect((await registry.getPermissionsForUser(streamId0, user0Address)).toString())
-    //             .to.equal([true, true, MAX_INT, ZERO, false].toString())
-    //         await registryFromUser1.transferPermissionToUser(streamId0, user0Address, PermissionType.Subscribe)
-    //         expect((await registry.getPermissionsForUser(streamId0, user1Address)).toString())
-    //             .to.equal([false, false, ZERO, ZERO, true].toString())
-    //         expect((await registry.getPermissionsForUser(streamId0, user0Address)).toString())
-    //             .to.equal([true, true, MAX_INT, MAX_INT, false].toString())
-    //         await registryFromUser1.transferPermissionToUser(streamId0, user0Address, PermissionType.Share)
-    //         expect((await registry.getPermissionsForUser(streamId0, user1Address)).toString())
-    //             .to.equal([false, false, ZERO, ZERO, false].toString())
-    //         expect((await registry.getPermissionsForUser(streamId0, user0Address)).toString())
-    //             .to.equal([true, true, MAX_INT, MAX_INT, true].toString())
-    //     })
-
-    //     it("negativetest transferPermissionToUser", async (): Promise<void> => {
-    //         await expect(registryFromUser1.transferPermissionToUser(streamId0, user0Address, PermissionType.Edit))
-    //             .to.be.revertedWith("error_noPermissionToTransfer")
-    //         await expect(registryFromUser1.transferPermissionToUser(streamId0, user0Address, PermissionType.Delete))
-    //             .to.be.revertedWith("error_noPermissionToTransfer")
-    //         await expect(registryFromUser1.transferPermissionToUser(streamId0, user0Address, PermissionType.Publish))
-    //             .to.be.revertedWith("error_noPermissionToTransfer")
-    //         await expect(registryFromUser1.transferPermissionToUser(streamId0, user0Address, PermissionType.Subscribe))
-    //             .to.be.revertedWith("error_noPermissionToTransfer")
-    //         await expect(registryFromUser1.transferPermissionToUser(streamId0, user0Address, PermissionType.Share))
-    //             .to.be.revertedWith("error_noPermissionToTransfer")
-    //     })
-    // })
 
     describe("EIP-2771 meta-transactions feature", () => {
         async function getCreateStreamMetaTx({

--- a/packages/network-contracts/test/hardhat/Registries/StreamRegistry.test.ts
+++ b/packages/network-contracts/test/hardhat/Registries/StreamRegistry.test.ts
@@ -52,14 +52,12 @@ const getBlocktime = async (): Promise<number> => {
 
 describe.only("StreamRegistry", async (): Promise<void> => {
     let wallets: WalletType[]
-    // let ensCacheFromAdmin: ENSCache
     let registry: StreamRegistry
     let registryFromUser0: StreamRegistry
     let registryFromUser1: StreamRegistry
     let registryFromMigrator: StreamRegistry
     let minimalForwarderFromUser0: MinimalForwarder
     let blocktime: number
-    // let registryFromUser1: StreamRegistry
     let adminAddress: string
     let user0Address: string
     let user1Address: string
@@ -199,7 +197,6 @@ describe.only("StreamRegistry", async (): Promise<void> => {
             }
             await expect(await registry.createStreamWithPermissions(newStreamPath, metadata1,
                 [adminAddress, trustedAddress], [permissionA, permissionB]))
-                // [trustedAddress], [permissionB]))
                 .to.emit(registry, "StreamCreated")
                 .withArgs(newStreamId, metadata1)
                 .to.emit(registry, "PermissionUpdated")


### PR DESCRIPTION
Also managed to squeeze in:
* setExpirationTimeForUserId (this is the only setter method that really makes sense: userIds are only supposed to have expiration times)
* grantPermissionForUserId, revokePermissionForUserId