### PR TITLE
Drop dead Polygon RPC url

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -287,9 +287,6 @@ export const config = {
                 "url": "https://rpc.ankr.com/polygon"
             },
             {
-                "url": "https://polygon.rpc.blxrbdn.com"
-            },
-            {
                 "url": "https://rpc-mainnet.matic.quiknode.pro"
             }
         ],


### PR DESCRIPTION
The RPC URL I remove in this PR causes consistent timeouts.

Requests are seen as pending for 30s:

<img width="1224" alt="Screenshot 2024-10-28 at 4 01 30 PM" src="https://github.com/user-attachments/assets/179f0ec4-e08e-40dc-95c6-698d2cc8d2d6">

Then turn red immediately after (fallback provider moves on to the next one):

![image](https://github.com/user-attachments/assets/7710d30f-f569-40c7-bf24-917857a858ce)