### PR TITLE
ETH-802 fix: create dummy `Delegator` entity when non-delegator undelegates

### DIFF
--- a/packages/network-contracts/README.md
+++ b/packages/network-contracts/README.md
@@ -38,7 +38,7 @@ The package exports all of the artifacts needed to interact with the contracts, 
 An example of how to use it can be seen in network-contracts/packages/network-contracts/scripts/tatum/streamrEnvDeployer.ts, that can be run with the streamrEnvDeployer npm task
 
 
-<h3>Proxy contracts</h3>
+### Proxy contracts
 
 The proxy enables upgradability of contract code without the need to change all addresses in software that talks to the contract and without the need to migrate data that is inside the old contract, that is being upgraded. Also the upgrade can only be controlled by a ProxyAdmin contract. To find out more visit
 https://docs.openzeppelin.com/contracts/3.x/api/proxy  and
@@ -51,7 +51,7 @@ npm run localDeployProxy
 then copy the Proxy and Proxyadmin addresses to the upgradeProxy.ts script and run it with
 ```
 npm run localUpgradeImpl
-````
+```
 
 # Changelog
 

--- a/packages/network-subgraphs/schema.graphql
+++ b/packages/network-subgraphs/schema.graphql
@@ -563,7 +563,7 @@ type QueueEntry @entity {
   operator: Operator!
   amount: BigInt!
   date: BigInt!
-  delegator: Delegator!
+  delegator: Delegator # can be null in case a non-delegator called `undelegate`, so there is no corresponding Delegator entity
 }
 
 # Plain events, saved "as-is". TODO: do we need and want them? Will they be expensive in the new decentralized subgraph?

--- a/packages/network-subgraphs/schema.graphql
+++ b/packages/network-subgraphs/schema.graphql
@@ -563,7 +563,7 @@ type QueueEntry @entity {
   operator: Operator!
   amount: BigInt!
   date: BigInt!
-  delegator: Delegator # can be null in case a non-delegator called `undelegate`, so there is no corresponding Delegator entity
+  delegator: Delegator!
 }
 
 # Plain events, saved "as-is". TODO: do we need and want them? Will they be expensive in the new decentralized subgraph?

--- a/packages/network-subgraphs/src/operator.ts
+++ b/packages/network-subgraphs/src/operator.ts
@@ -233,7 +233,7 @@ export function handleQueuedDataPayout(event: QueuedDataPayout): void {
     queueEntry.operator = operatorId
     queueEntry.amount = queuedAmount
     queueEntry.date = event.block.timestamp
-    queueEntry.delegator = delegator.id
+    queueEntry.delegator = delegatorId
     queueEntry.save()
 }
 

--- a/packages/network-subgraphs/src/operator.ts
+++ b/packages/network-subgraphs/src/operator.ts
@@ -226,7 +226,6 @@ export function handleQueuedDataPayout(event: QueuedDataPayout): void {
     ])
 
     // ETH-806 fix: in case a non-delegator called `undelegate`, a new Delegator entity is created
-    //   it will be cleaned up in handleQueueUpdated during payout, so no trash is caused by non-delegators
     const delegator = loadOrCreateDelegator(delegatorId)
     delegator.save() // no-op in the normal case of existing delegator
 

--- a/packages/network-subgraphs/src/operator.ts
+++ b/packages/network-subgraphs/src/operator.ts
@@ -225,7 +225,7 @@ export function handleQueuedDataPayout(event: QueuedDataPayout): void {
         operatorId, delegatorId, event.block.number.toString(), queuedAmount.toString()
     ])
 
-    // ETH-806 fix: in case a non-delegator called `undelegate`, a new Delegator entity is created
+    // ETH-802 fix: in case a non-delegator called `undelegate`, a new Delegator entity is created
     const delegator = loadOrCreateDelegator(delegatorId)
     delegator.save() // no-op in the normal case of existing delegator
 

--- a/packages/network-subgraphs/tests/integration/event-queue-test.js
+++ b/packages/network-subgraphs/tests/integration/event-queue-test.js
@@ -1,0 +1,40 @@
+/**
+ * Reproduction of ETH-802 bug
+ * 1) in network-subgraphs, run `npm run docker:buildLocalArch`
+ * 2) `streamr-docker-dev start deploy-network-subgraphs-fastchain`
+ * 3) Open `http://localhost:8800/subgraphs/name/streamr-dev/network-subgraphs/graphql`
+ *      and query `query MyQuery { queueEntries { delegator { id } } }`
+ * 4) run this file
+ * 5) Run the query again
+ *
+ * Before fix, it would error out with "Cannot return null for non-nullable field QueueEntry.delegator." or similar
+ *
+ * TODO: after we have integration tests for real (ETH-639), move this into a proper test
+ */
+
+const { Wallet, Contract, providers } = require("ethers")
+const { operatorABI } = require('../../../network-contracts/dist/src/exports')
+
+const LARGE_NUMBER = "0x01104d6706312fa73d0e00"
+
+async function main() {
+    const provider = new providers.JsonRpcProvider("http://10.200.10.1:8547")
+
+    const delegator = new Wallet("0x5e98cce00cff5dea6b454889f359a4ec06b9fa6b88e9d69b86de8e1c81887da0", provider)
+    const nonDelegator = new Wallet("0xe5af7834455b7239881b85be89d905d6881dcb4751063897f12be1b0dd546bdb", provider)
+
+    const operator = new Contract("0xb63c856cf861a88f4fa8587716fdc4e69cdf9ef1", operatorABI, provider)
+
+    console.log("Queue before: %o", await operator.undelegationQueue())
+
+    // clog up the undelegation queue
+    await operator.connect(delegator).undelegate(LARGE_NUMBER)
+
+    console.log("Queue after tx 1: %o", await operator.undelegationQueue())
+
+    // this "non-undelegation" won't be processed
+    await operator.connect(nonDelegator).undelegate(LARGE_NUMBER)
+
+    console.log("Queue after tx 2: %o", await operator.undelegationQueue())
+}
+main().catch(console.error)


### PR DESCRIPTION
## Background

Undelegation queue has the "future execution" element: it saves address of the "undelegation requestor" (called `delegator`) and amount. But all checks etc. happen in the payout, that is, when that queue item actually gets processed in `QueueModule._payOutFirstInQueue()`

This means stuff in the queue is allowed to be non-sensical at any given moment before processing: amount can be very large, the delegator not actually a delegator; this is in accordance with the contract logic. The contract is robust to these during payout.

Before this PR the subgraph handling logic assumed that all delegators were real delegators, i.e. this "future execution" assumptions were not taken into account.

Subgraph connects that address to a `Delegator` entity, but there might not exist such `Delegator` entity. This caused a problem with subgraph that assumed the address in the queue item must point to an existing `Delegator`.

In production e.g. this query failed:
```graphql
query {
  queueEntry(id: "0xc2fc20a3ad8f3496c147f3a8b11e5e9c5cbe9d19-54") {
    amount
    date
    id
    delegator {
      id
    }
  }
}
```
```
{
  "data": null,
  "errors": [
    {
      "message": "Null value resolved for non-null field `delegator`"
    }
  ]
}
```

## Fix

This PR implements a fix by creating dummy `Delegator` item if it doesn't already exist. The intention is that maybe that "undelegation requestor" actually becomes a delegator in the future. If that's the case, this dummy is just a pre-created `Delegator` instance.

## Future improvements

This implementation doesn't clean up the dummy `Delegator` entries. But trash is currently already created because `handleBalanceUpdate` doesn't remove `Delegator` entities that aren't delegating anywhere anymore (naive fix doesn't help since `QueueUpdate` gets called but not `BalanceUpdate` for these "pre-created" `Delegator` entities). This will be addressed in https://linear.app/streamr/issue/ETH-804/clean-up-old-delegator-entities-from-subgraph.

## Other considered ideas

- only store "undelegation queue item address" or "requestor address", not connecting it to the `Delegator` entity. This makes `querying` less flexible on happy paths.
- make `Delegator` nullable. The null delegator is a transient problem that gets cleared during the queue payout. Of course this might take time: generally it's the operator that frees up stakes or withdraws to pay out the queue.