### PR TITLE
test: Remove obsolete Linux x64-specific dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,8 +31,6 @@ jobs:
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci --no-audit
-      - name: Install linux x64 specific package
-        run: npm i @nomicfoundation/solidity-analyzer-linux-x64-gnu solidity-comments-linux-x64-gnu
       - name: Build and lint
         run: npm run build && npm run lint
       - name: Unit tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,8 +58,6 @@ jobs:
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci --no-audit
-      - name: Install linux x64 specific package
-        run: npm i @nomicfoundation/solidity-analyzer-linux-x64-gnu solidity-comments-linux-x64-gnu
       - name: Build all packages
         run: npm run build
       - name: Build fastchain image


### PR DESCRIPTION
It seems that these are not needed. Tested in `x86` AWS Linux. CI is green so this is also compatible with that Ubuntu 20.04 version.