### PR TITLE
test: Separate `build` and `lint` steps in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,8 +33,10 @@ jobs:
         run: npm ci --no-audit
       - name: Install linux x64 specific package
         run: npm i @nomicfoundation/solidity-analyzer-linux-x64-gnu solidity-comments-linux-x64-gnu
-      - name: Build and lint
-        run: npm run build && npm run lint
+      - name: Build
+        run: npm run build
+      - name: Lint
+        run: npm run lint
       - name: Unit tests
         run: npm run test
   fastchain-docker-image:


### PR DESCRIPTION
It is simpler to see the root cause when the tasks are separate steps.