### PR TITLE
Re-add platform-specific packages for CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,8 @@ jobs:
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci --no-audit
+      - name: (Re-)install packages that have platform-specific implementations
+        run: npm i @nomicfoundation/solidity-analyzer solidity-comments
       - name: Build
         run: npm run build
       - name: Lint


### PR DESCRIPTION
some packages need to be re-installed on the target machine so that they get the correct implementation.

In package-lock.json, we might have arm-version of @nomicfoundation/solidity-analyzer, so that gets installed in CI machine too. However, that machine needs the linux-x64-gnu version of the package. This is fixed by running npm install on those specific packages.

Specific error in CI, see e.g. https://github.com/streamr-dev/network-contracts/actions/runs/13110417595/job/36585239309

`HardhatError: HH18: You installed Hardhat with a corrupted lockfile due to the NPM bug #4828.`

https://github.com/NomicFoundation/hardhat/discussions/4937
suggests reason is "misidentifying the platform in @nomicfoundation/solidity-analyzer"

After adding that package, another error appears: `Error: Cannot find module 'solidity-comments-linux-x64-gnu'`

After adding that package as well, the run succeeds.
