### PR TITLE
refactor(npm-network-contracts): Capitalize ABI exports

### DIFF
--- a/packages/npm-network-contracts/src/exports.ts
+++ b/packages/npm-network-contracts/src/exports.ts
@@ -1,24 +1,24 @@
-export { abi as streamRegistryABI } from '../artifacts/contracts/StreamRegistry/StreamRegistryV5.sol/StreamRegistryV5.json'
+export { abi as StreamRegistryABI } from '../artifacts/contracts/StreamRegistry/StreamRegistryV5.sol/StreamRegistryV5.json'
 export type { StreamRegistryV5 as StreamRegistry } from '../typechain/contracts/StreamRegistry/StreamRegistryV5'
 
-export { abi as streamStorageRegistryABI } from
+export { abi as StreamStorageRegistryABI } from
     '../artifacts/contracts/StreamStorageRegistry/StreamStorageRegistryV2.sol/StreamStorageRegistryV2.json'
 export type { StreamStorageRegistryV2 as StreamStorageRegistry } from '../typechain/contracts/StreamStorageRegistry/StreamStorageRegistryV2'
 
-export { abi as nodeRegistryABI } from '../artifacts/contracts/NodeRegistry/NodeRegistry.sol/NodeRegistry.json'
+export { abi as NodeRegistryABI } from '../artifacts/contracts/NodeRegistry/NodeRegistry.sol/NodeRegistry.json'
 export type { NodeRegistry } from '../typechain/contracts/NodeRegistry/NodeRegistry'
 
-export { abi as operatorABI } from '../artifacts/contracts/OperatorTokenomics/Operator.sol/Operator.json'
+export { abi as OperatorABI } from '../artifacts/contracts/OperatorTokenomics/Operator.sol/Operator.json'
 export type { Operator } from '../typechain/contracts/OperatorTokenomics/Operator'
 
-export { abi as sponsorshipABI } from '../artifacts/contracts/OperatorTokenomics/Sponsorship.sol/Sponsorship.json'
+export { abi as SponsorshipABI } from '../artifacts/contracts/OperatorTokenomics/Sponsorship.sol/Sponsorship.json'
 export type { Sponsorship } from '../typechain/contracts/OperatorTokenomics/Sponsorship'
 
-export { abi as operatorFactoryABI } from '../artifacts/contracts/OperatorTokenomics/OperatorFactory.sol/OperatorFactory.json'
+export { abi as OperatorFactoryABI } from '../artifacts/contracts/OperatorTokenomics/OperatorFactory.sol/OperatorFactory.json'
 export type { OperatorFactory } from '../typechain/contracts/OperatorTokenomics/OperatorFactory'
 
-export { abi as sponsorshipFactoryABI } from '../artifacts/contracts/OperatorTokenomics/SponsorshipFactory.sol/SponsorshipFactory.json'
+export { abi as SponsorshipFactoryABI } from '../artifacts/contracts/OperatorTokenomics/SponsorshipFactory.sol/SponsorshipFactory.json'
 export type { SponsorshipFactory } from '../typechain/contracts/OperatorTokenomics/SponsorshipFactory'
 
-export { abi as streamrConfigABI } from '../artifacts/contracts/OperatorTokenomics/StreamrConfigV1_1.sol/StreamrConfigV1_1.json'
+export { abi as StreamrConfigABI } from '../artifacts/contracts/OperatorTokenomics/StreamrConfigV1_1.sol/StreamrConfigV1_1.json'
 export type { StreamrConfigV1_1 as StreamrConfig } from '../typechain/contracts/OperatorTokenomics/StreamrConfigV1_1'


### PR DESCRIPTION
Export ABIs as capitalized names, e.g. `StreamRegistryABI` instead of `streamRegistryABI`.

Maybe that naming style is more readable as the ABI is a constant, not a variable. Could have renamed e.g. to `STREAM_REGISTRY_ABI`, but maybe the capitalized version makes most sense as it refers to object instead of an ID.