### PR TITLE
feat(npm-network-contracts): [ETH-859] DATAv2 contract available via `@streamr/network-contracts` package

### DIFF
--- a/packages/npm-network-contracts/build.sh
+++ b/packages/npm-network-contracts/build.sh
@@ -7,9 +7,11 @@ cp -r ../network-contracts/contracts .
 hardhat compile
 
 # create minified ABIs
-artifact_files=$(find artifacts/contracts -type f -name '*.json' ! -name '*.dbg.json')
-artifact_files="${artifact_files}
-artifacts/@streamr/data-v2/flattened/DATAv2.sol/DATAv2.json"
+artifact_files=$(
+    find artifacts/contracts -type f -name '*.json' ! -name '*.dbg.json' &&
+    echo "artifacts/@streamr/data-v2/flattened/DATAv2.sol/DATAv2.json"
+)
+
 for artifact_file in $artifact_files; do
     abi_file="$(echo "$artifact_file" | sed 's#^artifacts/#abis/#')"
     mkdir -p "$(dirname "$abi_file")"

--- a/packages/npm-network-contracts/build.sh
+++ b/packages/npm-network-contracts/build.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 set -ex
 
-rm -rf contracts artifacts typechain
+rm -rf contracts artifacts typechain abis
 cp -r ../network-contracts/contracts .
 
 hardhat compile
 
 # create minified ABIs
 artifact_files=$(find artifacts/contracts -type f -name '*.json' ! -name '*.dbg.json')
+artifact_files="${artifact_files}
+artifacts/@streamr/data-v2/flattened/DATAv2.sol/DATAv2.json"
 for artifact_file in $artifact_files; do
     abi_file="$(echo "$artifact_file" | sed 's#^artifacts/#abis/#')"
     mkdir -p "$(dirname "$abi_file")"

--- a/packages/npm-network-contracts/hardhat.config.ts
+++ b/packages/npm-network-contracts/hardhat.config.ts
@@ -23,6 +23,15 @@ const config: HardhatUserConfig = {
                     },
                 },
             },
+            {
+                version: "0.8.6",
+                settings: {
+                    optimizer: {
+                        enabled: true,
+                        runs: 100,
+                    },
+                },
+            },
         ],
     },
     typechain: {
@@ -34,10 +43,10 @@ const config: HardhatUserConfig = {
             "@openzeppelin/contracts/metatx/MinimalForwarder.sol",
             "@opengsn/contracts/src/forwarder/Forwarder.sol",
             "@openzeppelin/contracts-upgradeable/metatx/MinimalForwarderUpgradeable.sol",
-            "@openzeppelin/contracts/interfaces/IERC1271.sol",
             "@ensdomains/ens-contracts/contracts/registry/FIFSRegistrar.sol",
             "@ensdomains/ens-contracts/contracts/resolvers/Resolver.sol",
-            "@ensdomains/ens-contracts/contracts/registry/ENSRegistry.sol"
+            "@ensdomains/ens-contracts/contracts/registry/ENSRegistry.sol",
+            "@streamr/data-v2/flattened/DATAv2.sol",
         ],
     },
 }

--- a/packages/npm-network-contracts/hardhat.config.ts
+++ b/packages/npm-network-contracts/hardhat.config.ts
@@ -43,6 +43,7 @@ const config: HardhatUserConfig = {
             "@openzeppelin/contracts/metatx/MinimalForwarder.sol",
             "@opengsn/contracts/src/forwarder/Forwarder.sol",
             "@openzeppelin/contracts-upgradeable/metatx/MinimalForwarderUpgradeable.sol",
+            "@openzeppelin/contracts/interfaces/IERC1271.sol",
             "@ensdomains/ens-contracts/contracts/registry/FIFSRegistrar.sol",
             "@ensdomains/ens-contracts/contracts/resolvers/Resolver.sol",
             "@ensdomains/ens-contracts/contracts/registry/ENSRegistry.sol",

--- a/packages/npm-network-contracts/hardhat.config.ts
+++ b/packages/npm-network-contracts/hardhat.config.ts
@@ -23,7 +23,7 @@ const config: HardhatUserConfig = {
                     },
                 },
             },
-            {
+            { // for DATAv2.sol compilation
                 version: "0.8.6",
                 settings: {
                     optimizer: {

--- a/packages/npm-network-contracts/package-lock.json
+++ b/packages/npm-network-contracts/package-lock.json
@@ -15,6 +15,7 @@
         "@opengsn/provider": "2.2.6",
         "@openzeppelin/contracts-upgradeable": "4.8.0",
         "@openzeppelin/contracts-upgradeable-4.4.2": "npm:@openzeppelin/contracts-upgradeable@4.4.2",
+        "@streamr/data-v2": "1.0.4",
         "hardhat": "2.22.2",
         "hardhat-dependency-compiler": "1.1.4"
       }
@@ -1113,7 +1114,6 @@
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -1127,7 +1127,6 @@
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -1971,6 +1970,25 @@
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4"
       }
+    },
+    "node_modules/@streamr/data-v2": {
+      "version": "1.0.4",
+      "resolved": "file:streamr-data-v2-1.0.4.tgz",
+      "integrity": "sha512-eZDeBrLjHuBJPGhOctxrbYs/strxRkvDL3pNgnv9oPOO1o+V4fLtgYkEA2IyF108edSnHnOPVJDr7T4naoXBlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@openzeppelin/contracts": "4.0.0",
+        "ethers": "^6.1.0",
+        "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/@streamr/data-v2/node_modules/@openzeppelin/contracts": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.0.0.tgz",
+      "integrity": "sha512-UcIJl/vUVjTr3H1yYXZi7Sr2PlXzBEHVUJKOUlVyzyy0FI8oQCCy0Wx+BuK/fojdnmLeMvUk4KUvhKUybP+C7Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -4848,7 +4866,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -4868,7 +4885,6 @@
       "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -4878,16 +4894,14 @@
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ethers/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ethjs-unit": {
       "version": "0.1.6",
@@ -9301,8 +9315,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsort": {
       "version": "0.0.1",
@@ -9509,7 +9522,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/packages/npm-network-contracts/package.json
+++ b/packages/npm-network-contracts/package.json
@@ -25,6 +25,7 @@
     "@opengsn/provider": "2.2.6",
     "@openzeppelin/contracts-upgradeable-4.4.2": "npm:@openzeppelin/contracts-upgradeable@4.4.2",
     "@openzeppelin/contracts-upgradeable": "4.8.0",
+    "@streamr/data-v2": "1.0.4",
     "hardhat": "2.22.2",
     "hardhat-dependency-compiler": "1.1.4"
   }

--- a/packages/npm-network-contracts/src/exports.ts
+++ b/packages/npm-network-contracts/src/exports.ts
@@ -1,3 +1,6 @@
+export { default as DATAv2ABI } from '../abis/@streamr/data-v2/flattened/DATAv2.sol/DATAv2.json'
+export type { DATAv2 } from '../typechain/@streamr/data-v2/flattened/DATAv2.sol/DATAv2'
+
 export { default as StreamRegistryABI } from '../abis/contracts/StreamRegistry/StreamRegistryV5.sol/StreamRegistryV5.json'
 export type { StreamRegistryV5 as StreamRegistry } from '../typechain/contracts/StreamRegistry/StreamRegistryV5'
 


### PR DESCRIPTION
## Background

The `DATAv2` contract implementation is in a separate repo https://github.com/streamr-dev/DATAv2

## Motivation

For end-user convenience it is good that all our contracts are available a single package (`@streamr/network-contracts`)

## Implementation

We added `DataV2` contract as a dependency for  Hardhat `dependencyCompiler`. It causes Hardhat to fetch the npm-published version of the contract and produce build artifacts (ABI and type definitions) locally for that contract.
 
As a consequence we just needed to add `DATAv2` type and `DATAv2ABI` export definitions to `exports.ts`. 

## Flattening

Ideally we'd just install the `@streamr/data-v2` package and add it to `dependencyCompiler`, but there were problems with dependency versions. `@streamr/data-v2` is compiled with `@openzeppelin/contracts` version 4.0.0, and some dependencies of `network-contracts` use 4.9.6; this isn't a problem to NPM nor to `solc`, but Hardhat throws HH700 errors that turned tricky to reason about.

Maybe upgrading the version in the token repository could've solved the problem, but I didn't want to make changes to the token bytecode for this ticket. But maybe those changes wouldn't really be a problem; made ticket ETH-862 to manage the token's dependencies once it's moved to the network-contracts monorepo.

So instead used a flattened version of `DATAv2.sol` from `@streamr/data-v2`, to avoid these dependency problems. 

## Future improvements

We could move `DATAv2` contract implementation to the `network-contracts` monorepo (ETH-799)