### PR TITLE
chore: Optimize `deploy-network-subgraphs-fastchain` startup

### DIFF
--- a/packages/network-subgraphs/start.sh
+++ b/packages/network-subgraphs/start.sh
@@ -1,8 +1,24 @@
 CONTAINER_ALREADY_STARTED="/firstrun/CONTAINER_ALREADY_STARTED_PLACEHOLDER"
+GRAPH_NODE_URL="http://streamr-dev-thegraph-node-fastchain:8000"
+
+wait_for_graph_node_start() {
+    while true; do
+        if curl --fail --silent --max-time 1 $GRAPH_NODE_URL; then
+            echo "Graph Node is ready"
+            break
+        else
+            echo "Waiting for Graph Node to start..."
+        fi
+        sleep 1s
+    done
+}
+
 if [ ! -e $CONTAINER_ALREADY_STARTED ]; then
     touch $CONTAINER_ALREADY_STARTED
-    echo "-- First container startup, waiting 30sec, then deploying subgraph --"
-    sleep 30s;
+    echo "-- First container startup: wait for Graph Node to start, then deploying subgraph --"
+    # TODO we could also wait for dev-chain-fast and postgres start, but in practice these are started almost immediately
+    # and therefore it makes sense to wait only for the Graph Node
+    wait_for_graph_node_start
     npm run create-docker-dev
     npm run deploy-docker-dev
 else


### PR DESCRIPTION
Poll instead of wait.

## Statistics

Before this change chain startup (`streamr-docker-dev start dev-chain-fast deploy-network-subgraphs-fastchain`) took about 44s, now it takes about 24s.

## Future improvements

Could poll also `dev-chain` and `postgres`, but this should also work without those.