### PR TITLE
feature(network-subgraphs): [ETH-875] Add stream IDs back to permission IDs in subgraph on IDs in subgraph

### DIFF
--- a/packages/network-subgraphs/README.md
+++ b/packages/network-subgraphs/README.md
@@ -52,6 +52,10 @@ can be recreated with the Dockerfile. To do so:
   * StreamRegistryV5 (Arbitrary length user id, ETH-787) deployment to Polygon
 * v0.0.10
   * Fixed log message
+* v0.0.12
+  * StreamPermission.id is now a hash of streamId and userId (ETH-867)
+* v0.0.13
+  * StreamPermission.id is now start of streamId + a hash of streamId and userId (ETH-875)
 
 # Developer notes
 

--- a/packages/network-subgraphs/src/streamRegistry.ts
+++ b/packages/network-subgraphs/src/streamRegistry.ts
@@ -8,7 +8,8 @@ import { Stream, StreamPermission } from '../generated/schema'
  * Hash the streamId and the userId, in order to get constant-length permission IDs (ETH-867)
  * This avoids indexing problems if the userId or streamId is very long (many kilobytes).
  *
- * TODO: once streamId is no longer possibly very long, remove the slice(0, 1000)
+ * TODO: after ETH-876 is solved, streamId can't be over-long, remove the slice(0, 1000) below
+ *       because it could cause some streams with same 1k-prefix to mix up when sorting
  **/
 function getPermissionId(streamId: string, userId: Bytes): string {
     return streamId.slice(0, 1000) + "-" + crypto.keccak256(Bytes.fromUTF8(streamId).concat(userId)).toHexString()

--- a/packages/network-subgraphs/src/streamRegistry.ts
+++ b/packages/network-subgraphs/src/streamRegistry.ts
@@ -6,10 +6,12 @@ import { Stream, StreamPermission } from '../generated/schema'
 
 /**
  * Hash the streamId and the userId, in order to get constant-length permission IDs (ETH-867)
- * This avoids indexing problems if the userId is very long (many kilobytes).
+ * This avoids indexing problems if the userId or streamId is very long (many kilobytes).
+ *
+ * TODO: once streamId is no longer possibly very long, remove the slice(0, 1000)
  **/
 function getPermissionId(streamId: string, userId: Bytes): string {
-    return crypto.keccak256(Bytes.fromUTF8(streamId).concat(userId)).toHexString()
+    return streamId.slice(0, 1000) + "-" + crypto.keccak256(Bytes.fromUTF8(streamId).concat(userId)).toHexString()
 }
 
 export function handleStreamCreation(event: StreamCreated): void {


### PR DESCRIPTION
# Changes:
* add streamId back to StreamPermission.id (although only the first 1k characters)

# Why:
* this solves two problems:
  * ETH-867 bug with overlong StreamPermission.id
  * NET-1461 bug with ordering/pagination problems in shipped StreamrClients

# Future work
Once overlong streamId problem is solved, we can remove the slicing (without risking re-introducing ETH-867).