### PR TITLE
feat(network-subgraphs): Add `idAsString` field

### DIFF
--- a/packages/network-subgraphs/schema.graphql
+++ b/packages/network-subgraphs/schema.graphql
@@ -35,6 +35,8 @@ type StreamPermission @entity {
 type Stream @entity {
   "stream ID = 'creator address'/'path' where path can be any string"
   id: ID!
+  "Contains same value as in the id field. This field allows us do to substring queries for the field id (by using idAsString_contains where clause)"
+  idAsString: String! @index
   "Stream metadata JSON"
   metadata: String!
   "Permissions that each Ethereum address owns to this stream"

--- a/packages/network-subgraphs/schema.graphql
+++ b/packages/network-subgraphs/schema.graphql
@@ -35,7 +35,7 @@ type StreamPermission @entity {
 type Stream @entity {
   "stream ID = 'creator address'/'path' where path can be any string"
   id: ID!
-  "Contains same value as in the id field. This field allows us do to substring queries for the field id (by using idAsString_contains where clause)"
+  "This field has the same value as the ID field. It enables us to perform substring queries on the id field using the idAsString_contains where clause"
   idAsString: String! @index
   "Stream metadata JSON"
   metadata: String!

--- a/packages/network-subgraphs/src/streamRegistry.ts
+++ b/packages/network-subgraphs/src/streamRegistry.ts
@@ -19,6 +19,7 @@ export function handleStreamCreation(event: StreamCreated): void {
     log.info('handleStreamCreation: id={} metadata={} blockNumber={}',
         [event.params.id, event.params.metadata, event.block.number.toString()])
     let stream = new Stream(event.params.id)
+    stream.idAsString = event.params.id,
     stream.metadata = event.params.metadata
     stream.createdAt = event.block.timestamp
     stream.updatedAt = event.block.timestamp


### PR DESCRIPTION
Added new field to `Stream` entity: `Stream#idAsString`. It has same value as in the `id` field. The field allows us do to substring queries for the field id (by using `idAsString_contains` where clause).

This feature is needed e.g. in https://github.com/streamr-dev/network/pull/3132.