### PR TITLE
fix: re-create Delegation entities on different ID

### DIFF
--- a/packages/network-subgraphs/schema.graphql
+++ b/packages/network-subgraphs/schema.graphql
@@ -393,7 +393,7 @@ type OperatorDailyBucket @entity {
 
 # Delegation events in an Operator contract signals trust in the operator
 type Delegation @entity {
-  "0xoperatorAddress-0xdelegatorAddress"
+  "0xoperatorAddress-0xdelegatorAddress-PastDelegationCount"
   id: ID!
   operator: Operator!
   delegator: Delegator!
@@ -412,6 +412,16 @@ type Delegation @entity {
 
   "earliest time this delegator can undelegate from this operator (0 if this.isSelfDelegation because it doesn't apply)"
   earliestUndelegationTimestamp: Int!
+}
+
+# Tracking past delegations to be able to create a clean running ID for the Delegation entity
+# Clean ID is required because otherwise we may hit a situation where we delete a Delegation (BalanceUpdate -> 0)
+#   then create it again later (e.g. Delegated event), and results in
+#   `internal error: impossible combination of entity operations: Remove and then Overwrite`
+type PastDelegationCount @entity {
+  "0xoperatorAddress-0xdelegatorAddress"
+  id: ID!
+  count: Int!
 }
 
 type Delegator @entity {

--- a/packages/network-subgraphs/src/helpers.ts
+++ b/packages/network-subgraphs/src/helpers.ts
@@ -7,6 +7,7 @@ import {
     Flag,
     Operator,
     OperatorDailyBucket,
+    PastDelegationCount,
     Project,
     ProjectStakeByUser,
     ProjectStakingDayBucket,
@@ -245,7 +246,13 @@ export function loadOrCreateOperatorDailyBucket(contractAddress: Address, timest
 }
 
 export function loadOrCreateDelegation(operator: Operator, delegatorId: string): Delegation {
-    const delegationId = operator.id + "-" + delegatorId
+    let pastDelegationCount = PastDelegationCount.load(operator.id + "-" + delegatorId)
+    if (pastDelegationCount == null) {
+        pastDelegationCount = new PastDelegationCount(operator.id + "-" + delegatorId)
+        pastDelegationCount.count = 0
+        pastDelegationCount.save()
+    }
+    const delegationId = operator.id + "-" + delegatorId + "-" + pastDelegationCount.count.toString()
     let delegation = Delegation.load(delegationId)
     if (delegation == null) {
         delegation = new Delegation(delegationId)


### PR DESCRIPTION
# Why

When a Delegation gets deleted (e.g. due to undelegation, after BalanceUpdate event sends a zero), and then later re-created (e.g. due to another delegation, BalanceUpdate sending non-zero), what can happen is that those events are indexed as if they happened in the same transactional indexing context, and this thegraph does not like, giving `internal error: impossible combination of entity operations: Remove and then Overwrite`

# Changes

Fix by appending a running count to the Delegation.id

# Implications / future work

Nothing *should* rely on the Delegation entity IDs; this assumption was been made before in a similar situation though, and proven wrong. We'll see.
