### PR TITLE
fix(dev-chain-fast): dev2 block.timestamp closer to wall clock time

### DIFF
--- a/packages/dev-chain-fast/hardhat.config.js
+++ b/packages/dev-chain-fast/hardhat.config.js
@@ -3,10 +3,16 @@ module.exports = {
     defaultNetwork: 'hardhat',
     networks: {
         hardhat: {
+            initialDate: "2025-01-01T00:00:00Z", // deploy.ts will set block timestamp to wall clock time after it's done
             gas: 12000000,
             blockGasLimit: 0x1fffffffffffff,
             allowUnlimitedContractSize: true,
             mining: {
+                // TODO: consider setting auto to false
+                //   pro: in real setting, many tx can go into the same block, with automine every tx gets its own block
+                //   pro: with auto:true, if tx are sent very fast, since each block must increment by at least 1 second
+                //     it may cause block timestamps to drift forward from the wall clock time; auto:false would fix this
+                //   con: tests will probably run slower
                 auto: true,
                 interval: 1000
             },

--- a/packages/dev-chain-fast/scripts/checkTimestamp.ts
+++ b/packages/dev-chain-fast/scripts/checkTimestamp.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env ts-node
+
+import { providers } from "ethers"
+import { config } from "@streamr/config"
+
+const {
+    CHAIN = "dev2",
+} = process.env
+
+const {
+    rpcEndpoints: [{ url: rpcUrlFromConfig }],
+} = (config as any)[CHAIN]
+
+const { log } = console
+
+export async function logTimestamp(): Promise<void> {
+    const provider = new providers.JsonRpcProvider(rpcUrlFromConfig)
+    log("Connected to %o", await provider.getNetwork())
+    const blockNumber = await provider.getBlockNumber()
+    const block = await provider.getBlock(blockNumber)
+    log("Timestamp from provider: %s (%s)", block.timestamp, new Date(block.timestamp * 1000).toISOString())
+    log("System time: %s (%s)", (Date.now() / 1000).toFixed(0), new Date().toISOString())
+    log("Difference: %s seconds", block.timestamp - (Date.now() / 1000))
+}
+logTimestamp().catch(console.error)

--- a/packages/dev-chain-fast/src/deploy.ts
+++ b/packages/dev-chain-fast/src/deploy.ts
@@ -37,6 +37,9 @@ async function main() {
     }
     console.log("Chain node is up, deploying contracts...")
     await deploy()
+
+    // set block timestamp to wall clock time
+    await provider.send("evm_mine", [ Math.ceil(Date.now() / 1000) ])
 }
 
 async function deploy() {


### PR DESCRIPTION
previously, EVM blocktime advanced with 1s on every tx because of automine feature (auto: true). Because the initial time was wall clock time, block timestamp after deployment was advanced by ~100 seconds.

Deployment still uses automine, but now the initial time is set to past, and corrected to wall clock time after the deployment is done.
