### PR TITLE
fix: deployment script unnecessarily added a trusted policy

### DIFF
--- a/packages/network-contracts/scripts/deployTokenomicsContracts.ts
+++ b/packages/network-contracts/scripts/deployTokenomicsContracts.ts
@@ -258,7 +258,7 @@ export default async function deployTokenomicsContracts(
             contracts.sponsorshipDefaultLeavePolicy!.address,
             contracts.sponsorshipVoteKickPolicy!.address,
             contracts.sponsorshipMaxOperatorsJoinPolicy!.address,
-            contracts.sponsorshipOperatorContractOnlyJoinPolicy!.address,
+            // contracts.sponsorshipOperatorContractOnlyJoinPolicy!.address, // doesn't need to be whitelisted, is added by the factory
         ])).wait()
         log("Done adding trusted policies (%s/tx/%s )", blockExplorerUrl, tr1.transactionHash)
 


### PR DESCRIPTION
# Changes

Remove the line that adds sponsorshipOperatorContractOnlyJoinPolicy

# Why

sponsorshipOperatorContractOnlyJoinPolicy isn't given by the Sponsorship deployer (it's added by the factory), so it's not checked against the trustedPolicies, and hence doesn't need to be added as a trusted policy, either

# Future work

remove the trusted policy in the existing deployments