### PR TITLE
chore(network-subgraphs): `Sponsorship#minOperators` is not nullable

### DIFF
--- a/packages/network-subgraphs/schema.graphql
+++ b/packages/network-subgraphs/schema.graphql
@@ -469,7 +469,7 @@ type Sponsorship @entity {
   maxOperators: Int
 
   "how many stakers are required so that Sponsorship isRunning(), i.e. starts paying"
-  minOperators: Int
+  minOperators: Int!
 
 
   ## Sponsorship state: live / updated after relevant transactions


### PR DESCRIPTION
Annotated the field as non-nullable in the GraphQL schema. The argument type for the field is `uint` in the `SponsorshipFactory#deploySponsorship`, and therefore it can't hold `null` value:
```solidity
function deploySponsorship(
    uint minOperatorCount,
    string calldata streamId,
    string calldata metadata,
    address[] calldata policies,
    uint[] calldata policyParams
)
```