### PR TITLE
chore(network-contracts): Descriptive network id name for `dev2`

### DIFF
--- a/packages/network-subgraphs/subgraph.yaml
+++ b/packages/network-subgraphs/subgraph.yaml
@@ -84,7 +84,7 @@ dataSources:
       file: ./src/streamStorageRegistry.ts
   - kind: ethereum/contract
     name: ProjectRegistryV1
-    network: dev2 # xDai means dev1
+    network: dev2
     source:
       address: "0x3523F6Ff285D2A3F79A53d1E0953BD41bb7f6022"
       abi: ProjectRegistryV1


### PR DESCRIPTION
Using `dev2` instead of `xDai` for the docker-dev subgraph definition file

## Future improvements

Rename `subgraph.yaml` to `subgraph_dev2.yaml` if possible? Or refactor subgraph yaml files so that we don't need multiple config files with significant amount of code duplication.