### PR TITLE
chore: Main branch name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
       - '*'
   push:
     branches:
-      - master
+      - main
 
 jobs:
   lint-and-unit-test:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This is a monorepo containing various smart contracts and subgraphs used by the 
 
 ## Main packages
 
-- [Network contracts](https://github.com/streamr-dev/network-contracts/tree/master/packages/network-contracts) The actual smart contracts used by the Streamr Network. Package exported from here has version 7.x.x and exports Typechain interfaces for Ethers v5.
-- [Network contracts NPM package](https://github.com/streamr-dev/network-contracts/tree/master/packages/npm-network-contracts) ABI and Typechain interfaces for the Streamr Network smart contracts for Ethers v6, plus scripts for interacting with the smart contracts.
-- [Network subgraphs](https://github.com/streamr-dev/network-contracts/tree/master/packages/network-subgraphs) The Graph subgraphs for many contracts in the `network-contracts` package
-- [config](https://github.com/streamr-dev/network-contracts/tree/master/packages/config) Addresses of deployed Streamr contracts on various chains, importable as an npm package
+- [Network contracts](https://github.com/streamr-dev/network-contracts/tree/main/packages/network-contracts) The actual smart contracts used by the Streamr Network. Package exported from here has version 7.x.x and exports Typechain interfaces for Ethers v5.
+- [Network contracts NPM package](https://github.com/streamr-dev/network-contracts/tree/main/packages/npm-network-contracts) ABI and Typechain interfaces for the Streamr Network smart contracts for Ethers v6, plus scripts for interacting with the smart contracts.
+- [Network subgraphs](https://github.com/streamr-dev/network-contracts/tree/main/packages/network-subgraphs) The Graph subgraphs for many contracts in the `network-contracts` package
+- [config](https://github.com/streamr-dev/network-contracts/tree/main/packages/config) Addresses of deployed Streamr contracts on various chains, importable as an npm package

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -40,5 +40,5 @@
     "bugs": {
         "url": "https://github.com/streamr-dev/network-contracts/issues"
     },
-    "homepage": "https://github.com/streamr-dev/network-contracts/tree/master/packages/config#readme"
+    "homepage": "https://github.com/streamr-dev/network-contracts/tree/main/packages/config#readme"
 }


### PR DESCRIPTION
Changed main branch to be `main` instead of `master`. It is the new standard. After this PR we can use some tools which assume the main branch name to be `main`.

## Changes

- CI config
- URLs to files in GitHub repo

## Related TODO

- `git branch -m master main`
- `git push -u origin main`
- configure main branch in GitHub settings
- `git push origin --delete master`