### PR TITLE
chore(dev-chain-fast): Remove `@dataunions/contracts` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -286,10 +286,6 @@
         "kuler": "^2.0.0"
       }
     },
-    "node_modules/@dataunions/contracts": {
-      "version": "3.0.8",
-      "license": "UNLICENSED"
-    },
     "node_modules/@ensdomains/buffer": {
       "version": "0.1.1"
     },
@@ -29950,7 +29946,6 @@
       "version": "0.1.0",
       "license": "STREAMR NETWORK OPEN SOURCE LICENSE",
       "dependencies": {
-        "@dataunions/contracts": "^3.0.8",
         "@streamr/hub-contracts": "file:../hub-contracts",
         "@streamr/network-contracts": "file:../network-contracts",
         "hardhat": "2.22.9"

--- a/packages/dev-chain-fast/package.json
+++ b/packages/dev-chain-fast/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@streamr/hub-contracts": "file:../hub-contracts",
     "@streamr/network-contracts": "file:../network-contracts",
-    "@dataunions/contracts": "^3.0.8",
     "hardhat": "2.22.9"
   },
   "devDependencies": {


### PR DESCRIPTION
This dependency is no longer needed.