### PR TITLE
doc(network-contracts): fix misleading comment

### DIFF
--- a/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
+++ b/packages/network-contracts/contracts/OperatorTokenomics/Operator.sol
@@ -135,7 +135,7 @@ contract Operator is Initializable, ERC2771ContextUpgradeable, IERC677Receiver, 
     Sponsorship[] public sponsorships;
     mapping(Sponsorship => uint) public indexOfSponsorships; // sponsorships array index PLUS ONE! use 0 as "is it already in the array?" check
 
-    /** stake in a Sponsorship, in DATA-wei */
+    /** staked in a Sponsorship, in DATA-wei. NOT same as Sponsorship.stakedWei, which should equal stakedInto - slashedIn */
     mapping(Sponsorship => uint) public stakedInto;
     /** slashed in a Sponsorship, in DATA-wei */
     mapping(Sponsorship => uint) public slashedIn;


### PR DESCRIPTION
Operator.stakedInto is somewhat internal bookkeeping thing; and old comment made it sound like it should equal Sponsorship.stakedWei, while this certainly shouldn't be the case.
