### PR TITLE
build: remove hardhat-contract-sizer output

### DIFF
--- a/packages/network-contracts/hardhat.config.ts
+++ b/packages/network-contracts/hardhat.config.ts
@@ -5,7 +5,7 @@ import "hardhat-ignore-warnings"
 import "solidity-coverage"
 import "hardhat-dependency-compiler"
 import "@nomiclabs/hardhat-etherscan"
-import "hardhat-contract-sizer"
+// import "hardhat-contract-sizer"
 // import "hardhat-gas-reporter"
 
 import "./tasks/copyFilesAfterCompilation"
@@ -195,12 +195,12 @@ const config: HardhatUserConfig = {
     mocha: {
         timeout: 100000000
     },
-    contractSizer: {
-        alphaSort: true,
-        disambiguatePaths: false,
-        runOnCompile: true,
-        strict: true,
-    },
+    // contractSizer: {
+    //     alphaSort: true,
+    //     disambiguatePaths: false,
+    //     runOnCompile: true,
+    //     strict: true,
+    // },
     etherscan: {
         apiKey: {
             polygon: process.env.ETHERSCAN_KEY || "",


### PR DESCRIPTION
it's just spam now, only useful when changing the contracts
