### PR TITLE
chore(network-contracts): [ETH-899] Add Hardhat type definitions

### DIFF
--- a/packages/network-contracts/tsconfig.json
+++ b/packages/network-contracts/tsconfig.json
@@ -15,6 +15,6 @@
     },
     "include": ["./scripts", "./test", "./typechain", "test-contracts", "./src"],
     "files": [
-      "./hardhat.config.ts"
+      "./hardhat.config.ts", "types/hardhat-type-extensions.d.ts"
     ]
 }

--- a/packages/network-contracts/tsconfig.json
+++ b/packages/network-contracts/tsconfig.json
@@ -15,6 +15,6 @@
     },
     "include": ["./scripts", "./test", "./typechain", "test-contracts", "./src"],
     "files": [
-      "./hardhat.config.ts", "types/hardhat-type-extensions.d.ts"
+      "./hardhat.config.ts", "./types/hardhat-type-extensions.d.ts"
     ]
 }

--- a/packages/network-contracts/types/hardhat-type-extensions.d.ts
+++ b/packages/network-contracts/types/hardhat-type-extensions.d.ts
@@ -1,0 +1,23 @@
+/*
+ * Hardhat should automatically detect the correct types. For example, the import style we use should work fine:
+ * import { upgrades, ethers as hardhatEthers } from "hardhat"
+ * 
+ * However, for some reason, these imports failed without this type definition file. Compilation with "npx tsc" 
+ * resulted in the following errors:
+ * - Module '"hardhat"' has no exported member 'upgrades'
+ * - Module '"hardhat"' has no exported member 'ethers'
+ * 
+ * The root cause might be that we are using outdated versions of Hardhat, OpenZeppelin, or Ethers, or our 
+ * monorepo configuration might be incorrect. When upgrading Hardhat or related packages, we should
+ * verify whether this file is still necessary.
+ */ 
+import type { ethers } from "ethers"
+import type { HardhatUpgrades } from "@openzeppelin/hardhat-upgrades"
+import "hardhat/types/runtime"
+
+declare module "hardhat/types/runtime" {
+    interface HardhatRuntimeEnvironment {
+        ethers: typeof ethers & HardhatEthersHelpers
+        upgrades: HardhatUpgrades
+    }
+}


### PR DESCRIPTION
Added an explicit type definition files for Hardhat. For some reason Hardhat doesn't find the correct type information without this file. See comments of `hardhat-type-extensions.d.ts` for details.